### PR TITLE
Feature/add pubsub resource support

### DIFF
--- a/policy/pubsub/common_pubsub_subscriptions.rego
+++ b/policy/pubsub/common_pubsub_subscriptions.rego
@@ -1,0 +1,25 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.subscriptions
+
+policies [policy_name] {
+    policy := data.gcp.pubsub.projects.subscriptions.policy[policy_name]
+}
+
+violations [policy_name] {
+    policy := data.gcp.pubsub.projects.subscriptions.policy[policy_name]
+    policy.valid != true
+}

--- a/policy/pubsub/common_pubsub_subscriptions_iam.rego
+++ b/policy/pubsub/common_pubsub_subscriptions_iam.rego
@@ -1,0 +1,25 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.subscriptions.iam
+
+policies [policy_name] {
+    policy := data.gcp.pubsub.projects.subscriptions.iam.policy[policy_name]
+}
+
+violations [policy_name] {
+    policy := data.gcp.pubsub.projects.subscriptions.iam.policy[policy_name]
+    policy.valid != true
+}

--- a/policy/pubsub/common_pubsub_topics.rego
+++ b/policy/pubsub/common_pubsub_topics.rego
@@ -1,0 +1,25 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.topics
+
+policies [policy_name] {
+    policy := data.gcp.pubsub.projects.topics.policy[policy_name]
+}
+
+violations [policy_name] {
+    policy := data.gcp.pubsub.projects.topics.policy[policy_name]
+    policy.valid != true
+}

--- a/policy/pubsub/common_pubsub_topics_iam.rego
+++ b/policy/pubsub/common_pubsub_topics_iam.rego
@@ -1,0 +1,25 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.topics.iam
+
+policies [policy_name] {
+    policy := data.gcp.pubsub.projects.topics.iam.policy[policy_name]
+}
+
+violations [policy_name] {
+    policy := data.gcp.pubsub.projects.topics.iam.policy[policy_name]
+    policy.valid != true
+}

--- a/policy/pubsub/subscriptions_iam_disallow_allauthenticatedusers.rego
+++ b/policy/pubsub/subscriptions_iam_disallow_allauthenticatedusers.rego
@@ -1,0 +1,74 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.subscriptions.iam.policy.disallow_allauthenticatedusers
+
+#####
+# Resource metadata
+#####
+
+labels = input._resource.labels
+
+#####
+# Policy evaluation
+#####
+
+default valid = true
+
+# Check if there is a binding for *allAuthenticatedUsers*
+valid = false {
+  # Check for bad policy
+  input.bindings[_].members[_] == "allAuthenticatedUsers"
+
+  # Just in case labels are not in the input
+  not labels
+} else = false {
+  input.bindings[_].members[_] == "allAuthenticatedUsers"
+
+  # Also, make sure this resource isn't excluded by label
+  not data.exclusions.label_exclude(labels)
+}
+
+#####
+# Remediation
+#####
+
+# Make a copy of the input, omitting the bindings
+remediate[key] = value {
+ key != "bindings"
+ input[key]=value
+}
+
+# Now rebuild the bindings
+remediate[key] = value {
+  key := "bindings"
+  value := [binding | binding := _bindings[_]
+    # Remove any binding that no longer have any members
+    binding.members != []
+  ]
+}
+
+# Pass all binding through the fix_binding function
+_bindings = [_fix_binding(binding) | binding := input.bindings[_]]
+
+# The fixed bindings are just the expected fields with members filtered
+_fix_binding(b) = {"members": _remove_bad_members(b.members), "role": b.role}
+
+# Given a list of members, remove the bad one(s)
+_remove_bad_members(members) = m {
+  m = [member | member := members[_]
+    member != "allAuthenticatedUsers"
+  ]
+}

--- a/policy/pubsub/subscriptions_iam_disallow_allauthenticatedusers_test.rego
+++ b/policy/pubsub/subscriptions_iam_disallow_allauthenticatedusers_test.rego
@@ -1,0 +1,114 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.subscriptions.iam.policy.disallow_allauthenticatedusers
+
+test_valid_policies {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+    ],
+   "_resource": {
+      "labels": {
+      }
+    }
+  }
+}
+
+test_valid_policies_with_override {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+   ],
+   "_resource": {
+      "labels": {
+         "forseti-enforcer": "disable"
+      }
+    }
+  }
+}
+
+test_valid_policies_missing_labels {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+   ]
+  }
+}
+
+test_invalid_policies {
+  not valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "allAuthenticatedUsers"
+         ]
+      }
+    ],
+   "_resource": {
+      "labels": {
+      }
+    }
+  }
+}
+
+test_invalid_policies_with_override {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld",
+            "allAuthenticatedUsers"
+         ]
+      }
+   ],
+   "_resource": {
+      "labels": {
+         "forseti-enforcer": "disable"
+      }
+    }
+  }
+}
+
+test_invalid_policies_missing_labels {
+  not valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld",
+            "allAuthenticatedUsers"
+         ]
+      }
+   ]
+  }
+}

--- a/policy/pubsub/subscriptions_iam_disallow_allusers.rego
+++ b/policy/pubsub/subscriptions_iam_disallow_allusers.rego
@@ -1,0 +1,74 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.subscriptions.iam.policy.disallow_allusers
+
+#####
+# Resource metadata
+#####
+
+labels = input._resource.labels
+
+#####
+# Policy evaluation
+#####
+
+default valid = true
+
+# Check if there is a binding for *allUsers*
+valid = false {
+  # Check for bad policy
+  input.bindings[_].members[_] == "allUsers"
+
+  # Just in case labels are not in the input
+  not labels
+} else = false {
+  input.bindings[_].members[_] == "allUsers"
+
+  # Also, make sure this resource isn't excluded by label
+  not data.exclusions.label_exclude(labels)
+}
+
+#####
+# Remediation
+#####
+
+# Make a copy of the input, omitting the bindings
+remediate[key] = value {
+ key != "bindings"
+ input[key]=value
+}
+
+# Now rebuild the bindings
+remediate[key] = value {
+  key := "bindings"
+  value := [binding | binding := _bindings[_]
+    # Remove any binding that no longer have any members
+    binding.members != []
+  ]
+}
+
+# Pass all binding through the fix_binding function
+_bindings = [_fix_binding(binding) | binding := input.bindings[_]]
+
+# The fixed bindings are just the expected fields with members filtered
+_fix_binding(b) = {"members": _remove_bad_members(b.members), "role": b.role}
+
+# Given a list of members, remove the bad one(s)
+_remove_bad_members(members) = m {
+  m = [member | member := members[_]
+    member != "allUsers"
+  ]
+}

--- a/policy/pubsub/subscriptions_iam_disallow_allusers_test.rego
+++ b/policy/pubsub/subscriptions_iam_disallow_allusers_test.rego
@@ -1,0 +1,114 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.subscriptions.iam.policy.disallow_allusers
+
+test_valid_policies {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+    ],
+   "_resource": {
+      "labels": {
+      }
+    }
+  }
+}
+
+test_valid_policies_with_override {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+   ],
+   "_resource": {
+      "labels": {
+         "forseti-enforcer": "disable"
+      }
+    }
+  }
+}
+
+test_valid_policies_missing_labels {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+   ]
+  }
+}
+
+test_invalid_policies {
+  not valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "allUsers"
+         ]
+      }
+    ],
+   "_resource": {
+      "labels": {
+      }
+    }
+  }
+}
+
+test_invalid_policies_with_override {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld",
+            "allUsers"
+         ]
+      }
+   ],
+   "_resource": {
+      "labels": {
+         "forseti-enforcer": "disable"
+      }
+    }
+  }
+}
+
+test_invalid_policies_missing_labels {
+  not valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld",
+            "allUsers"
+         ]
+      }
+   ]
+  }
+}

--- a/policy/pubsub/topics_iam_disallow_allauthenticatedusers.rego
+++ b/policy/pubsub/topics_iam_disallow_allauthenticatedusers.rego
@@ -1,0 +1,74 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.topics.iam.policy.disallow_allauthenticatedusers
+
+#####
+# Resource metadata
+#####
+
+labels = input._resource.labels
+
+#####
+# Policy evaluation
+#####
+
+default valid = true
+
+# Check if there is a binding for *allAuthenticatedUsers*
+valid = false {
+  # Check for bad policy
+  input.bindings[_].members[_] == "allAuthenticatedUsers"
+
+  # Just in case labels are not in the input
+  not labels
+} else = false {
+  input.bindings[_].members[_] == "allAuthenticatedUsers"
+
+  # Also, make sure this resource isn't excluded by label
+  not data.exclusions.label_exclude(labels)
+}
+
+#####
+# Remediation
+#####
+
+# Make a copy of the input, omitting the bindings
+remediate[key] = value {
+ key != "bindings"
+ input[key]=value
+}
+
+# Now rebuild the bindings
+remediate[key] = value {
+  key := "bindings"
+  value := [binding | binding := _bindings[_]
+    # Remove any binding that no longer have any members
+    binding.members != []
+  ]
+}
+
+# Pass all binding through the fix_binding function
+_bindings = [_fix_binding(binding) | binding := input.bindings[_]]
+
+# The fixed bindings are just the expected fields with members filtered
+_fix_binding(b) = {"members": _remove_bad_members(b.members), "role": b.role}
+
+# Given a list of members, remove the bad one(s)
+_remove_bad_members(members) = m {
+  m = [member | member := members[_]
+    member != "allAuthenticatedUsers"
+  ]
+}

--- a/policy/pubsub/topics_iam_disallow_allauthenticatedusers_test.rego
+++ b/policy/pubsub/topics_iam_disallow_allauthenticatedusers_test.rego
@@ -1,0 +1,114 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.topics.iam.policy.disallow_allauthenticatedusers
+
+test_valid_policies {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+    ],
+   "_resource": {
+      "labels": {
+      }
+    }
+  }
+}
+
+test_valid_policies_with_override {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+   ],
+   "_resource": {
+      "labels": {
+         "forseti-enforcer": "disable"
+      }
+    }
+  }
+}
+
+test_valid_policies_missing_labels {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+   ]
+  }
+}
+
+test_invalid_policies {
+  not valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "allAuthenticatedUsers"
+         ]
+      }
+    ],
+   "_resource": {
+      "labels": {
+      }
+    }
+  }
+}
+
+test_invalid_policies_with_override {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld",
+            "allAuthenticatedUsers"
+         ]
+      }
+   ],
+   "_resource": {
+      "labels": {
+         "forseti-enforcer": "disable"
+      }
+    }
+  }
+}
+
+test_invalid_policies_missing_labels {
+  not valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld",
+            "allAuthenticatedUsers"
+         ]
+      }
+   ]
+  }
+}

--- a/policy/pubsub/topics_iam_disallow_allusers.rego
+++ b/policy/pubsub/topics_iam_disallow_allusers.rego
@@ -1,0 +1,74 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.topics.iam.policy.disallow_allusers
+
+#####
+# Resource metadata
+#####
+
+labels = input._resource.labels
+
+#####
+# Policy evaluation
+#####
+
+default valid = true
+
+# Check if there is a binding for *allUsers*
+valid = false {
+  # Check for bad policy
+  input.bindings[_].members[_] == "allUsers"
+
+  # Just in case labels are not in the input
+  not labels
+} else = false {
+  input.bindings[_].members[_] == "allUsers"
+
+  # Also, make sure this resource isn't excluded by label
+  not data.exclusions.label_exclude(labels)
+}
+
+#####
+# Remediation
+#####
+
+# Make a copy of the input, omitting the bindings
+remediate[key] = value {
+ key != "bindings"
+ input[key]=value
+}
+
+# Now rebuild the bindings
+remediate[key] = value {
+  key := "bindings"
+  value := [binding | binding := _bindings[_]
+    # Remove any binding that no longer have any members
+    binding.members != []
+  ]
+}
+
+# Pass all binding through the fix_binding function
+_bindings = [_fix_binding(binding) | binding := input.bindings[_]]
+
+# The fixed bindings are just the expected fields with members filtered
+_fix_binding(b) = {"members": _remove_bad_members(b.members), "role": b.role}
+
+# Given a list of members, remove the bad one(s)
+_remove_bad_members(members) = m {
+  m = [member | member := members[_]
+    member != "allUsers"
+  ]
+}

--- a/policy/pubsub/topics_iam_disallow_allusers_test.rego
+++ b/policy/pubsub/topics_iam_disallow_allusers_test.rego
@@ -1,0 +1,114 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.pubsub.projects.topics.iam.policy.disallow_allusers
+
+test_valid_policies {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+    ],
+   "_resource": {
+      "labels": {
+      }
+    }
+  }
+}
+
+test_valid_policies_with_override {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+   ],
+   "_resource": {
+      "labels": {
+         "forseti-enforcer": "disable"
+      }
+    }
+  }
+}
+
+test_valid_policies_missing_labels {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld"
+         ]
+      }
+   ]
+  }
+}
+
+test_invalid_policies {
+  not valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "allUsers"
+         ]
+      }
+    ],
+   "_resource": {
+      "labels": {
+      }
+    }
+  }
+}
+
+test_invalid_policies_with_override {
+  valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld",
+            "allUsers"
+         ]
+      }
+   ],
+   "_resource": {
+      "labels": {
+         "forseti-enforcer": "disable"
+      }
+    }
+  }
+}
+
+test_invalid_policies_missing_labels {
+  not valid with input as {
+   "bindings": [
+      {
+         "role": "roles/storage.legacyBucketReader",
+         "members": [
+            "your_user@your_org.tld",
+            "allUsers"
+         ]
+      }
+   ]
+  }
+}

--- a/rpe/exceptions.py
+++ b/rpe/exceptions.py
@@ -38,5 +38,6 @@ def is_retryable_exception(err):
 class NoSuchEndpoint(URLError):
     pass
 
+
 class NoPossibleRemediation(Exception):
     pass

--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -74,6 +74,8 @@ class GoogleAPIResource(Resource):
             'compute.instances': GcpComputeInstance,
             'cloudresourcemanager.projects': GcpProject,
             'cloudresourcemanager.projects.iam': GcpProjectIam,
+            'pubsub.projects.subscriptions': GcpPubsubSubscription,
+            'pubsub.projects.subscriptions.iam': GcpPubsubSubscriptionIam,
             'pubsub.projects.topics': GcpPubsubTopic,
             'pubsub.projects.topics.iam': GcpPubsubTopicIam,
             'sqladmin.instances': GcpSqlInstance,
@@ -177,6 +179,60 @@ class GcpComputeInstance(GoogleAPIResource):
             'instance': self.resource_data['resource_name'],
             'zone': self.resource_data['resource_location'],
             'project': self.resource_data['project_id']
+        }
+
+
+class GcpPubsubSubscription(GoogleAPIResource):
+
+    service_name = "pubsub"
+    resource_path = "projects.subscriptions"
+    version = "v1"
+    update_method = "patch"
+
+    def _get_request_args(self):
+        return {
+            'subscription': 'projects/{}/subscriptions/{}'.format(
+                self.resource_data['project_id'],
+                self.resource_data['resource_name']
+            )
+        }
+
+    def _update_request_args(self, body):
+        return {
+            'name': 'projects/{}/subscriptions/{}'.format(
+                self.resource_data['project_id'],
+                self.resource_data['resource_name']
+            ),
+            'body': {
+                'subscription': body,
+                'updateMask': 'labels,ack_deadline_seconds,push_config,message_retention_duration,retain_acked_messages,expiration_policy'
+            }
+        }
+
+
+class GcpPubsubSubscriptionIam(GcpPubsubSubscription):
+
+    resource_property = 'iam'
+    get_method = "getIamPolicy"
+    update_method = "setIamPolicy"
+
+    def _get_request_args(self):
+        return {
+            'resource': 'projects/{}/subscriptions/{}'.format(
+                self.resource_data['project_id'],
+                self.resource_data['resource_name']
+            )
+        }
+
+    def _update_request_args(self, body):
+        return {
+            'resource': 'projects/{}/subscriptions/{}'.format(
+                self.resource_data['project_id'],
+                self.resource_data['resource_name']
+            ),
+            'body': {
+                'policy': body
+            }
         }
 
 

--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -74,6 +74,8 @@ class GoogleAPIResource(Resource):
             'compute.instances': GcpComputeInstance,
             'cloudresourcemanager.projects': GcpProject,
             'cloudresourcemanager.projects.iam': GcpProjectIam,
+            'pubsub.projects.topics': GcpPubsubTopic,
+            'pubsub.projects.topics.iam': GcpPubsubTopicIam,
             'sqladmin.instances': GcpSqlInstance,
             'storage.buckets': GcpStorageBucket,
             'storage.buckets.iam': GcpStorageBucketIamPolicy
@@ -175,6 +177,61 @@ class GcpComputeInstance(GoogleAPIResource):
             'instance': self.resource_data['resource_name'],
             'zone': self.resource_data['resource_location'],
             'project': self.resource_data['project_id']
+        }
+
+
+class GcpPubsubTopic(GoogleAPIResource):
+
+    service_name = "pubsub"
+    resource_path = "projects.topics"
+    version = "v1"
+    update_method = "patch"
+
+    def _get_request_args(self):
+        return {
+            'topic': 'projects/{}/topics/{}'.format(
+                self.resource_data['project_id'],
+                self.resource_data['resource_name']
+            )
+        }
+
+    def _update_request_args(self, body):
+        return {
+            'name': 'projects/{}/topics/{}'.format(
+                self.resource_data['project_id'],
+                self.resource_data['resource_name']
+            ),
+            'body': {
+                'topic': body,
+                # the name field is immutable
+                'updateMask': 'labels'
+            }
+        }
+
+
+class GcpPubsubTopicIam(GcpPubsubTopic):
+
+    resource_property = "iam"
+    get_method = "getIamPolicy"
+    update_method = "setIamPolicy"
+
+    def _get_request_args(self):
+        return {
+            'resource': 'projects/{}/topics/{}'.format(
+                self.resource_data['project_id'],
+                self.resource_data['resource_name']
+            )
+        }
+
+    def _update_request_args(self, body):
+        return {
+            'resource': 'projects/{}/topics/{}'.format(
+                self.resource_data['project_id'],
+                self.resource_data['resource_name']
+            ),
+            'body': {
+                'policy': body
+            }
         }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,6 @@ deps =
        pytest
        pytest-cov
 commands = pytest --cov=rpe --capture=no --cov-report=term-missing
+
+[flake8]
+ignore = E501


### PR DESCRIPTION
Add resource support for the following:
* Pub/Sub topics
* Pub/Sub topics iam policy
* Pub/Sub subscriptions
* Pub/Sub subscriptions iam policy

Add policies that disallow `allUsers` and `allAuthenticatedUsers` from Iam policies for topics and subscriptions.
