### PR TITLE
Implement full resource names for gcp resources

### DIFF
--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -164,6 +164,8 @@ class GoogleAPIResource(Resource):
         else:
             asset = method(**self._get_request_args()).execute()
 
+        asset['_full_resource_name'] = self.full_resource_name()
+
         # if this asset is a property, inject its parent
         if self.is_property():
             parent = self.parent_resource.get()
@@ -178,8 +180,9 @@ class GoogleAPIResource(Resource):
     def update(self, body):
 
         # remove injected data before attempting update
-        if self.is_property() and '_resource' in body:
-            del body['_resource']
+        for key in body:
+            if key.startswith('_'):
+                del body[key]
 
         method = getattr(self.service, self.update_method)
         return method(**self._update_request_args(body)).execute()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import collections
 import pytest
 
 from rpe.resources import Resource
@@ -31,129 +32,131 @@ from rpe.resources.gcp import GcpStorageBucketIamPolicy
 test_project = "my_project"
 test_resource_name = "my_resource"
 
+ResourceTestCase = collections.namedtuple('ResourceTestCase', 'input cls type name')
+
 test_cases = [
-    (
-        {
+    ResourceTestCase(
+        input={
             'resource_type': 'bigquery.datasets',
             'resource_name': test_resource_name,
             'project_id': test_project
         },
-        GcpBigqueryDataset,
-        'gcp.bigquery.datasets',
-        '//bigquery.googleapis.com/projects/my_project/datasets/my_resource'
+        cls=GcpBigqueryDataset,
+        type='gcp.bigquery.datasets',
+        name='//bigquery.googleapis.com/projects/my_project/datasets/my_resource'
     ),
-    (
-        {
+    ResourceTestCase(
+        input={
             'resource_type': 'compute.instances',
             'resource_name': test_resource_name,
             'resource_location': 'us-central1-a',
             'project_id': test_project
         },
-        GcpComputeInstance,
-        'gcp.compute.instances',
-        '//compute.googleapis.com/projects/my_project/zones/us-central1-a/instances/my_resource'
+        cls=GcpComputeInstance,
+        type='gcp.compute.instances',
+        name='//compute.googleapis.com/projects/my_project/zones/us-central1-a/instances/my_resource'
     ),
-    (
-        {
+    ResourceTestCase(
+        input={
             'resource_type': 'cloudresourcemanager.projects',
             'resource_name': test_project,
             'project_id': test_project
         },
-        GcpProject,
-        'gcp.cloudresourcemanager.projects',
-        '//cloudresourcemanager.googleapis.com/projects/my_project'
+        cls=GcpProject,
+        type='gcp.cloudresourcemanager.projects',
+        name='//cloudresourcemanager.googleapis.com/projects/my_project'
     ),
-    (
-        {
+    ResourceTestCase(
+        input={
             'resource_type': 'cloudresourcemanager.projects.iam',
             'resource_name': test_project,
             'project_id': test_project
         },
-        GcpProjectIam,
-        'gcp.cloudresourcemanager.projects.iam',
-        '//cloudresourcemanager.googleapis.com/projects/my_project'
+        cls=GcpProjectIam,
+        type='gcp.cloudresourcemanager.projects.iam',
+        name='//cloudresourcemanager.googleapis.com/projects/my_project'
     ),
-    (
-        {
+    ResourceTestCase(
+        input={
             'resource_type': 'pubsub.projects.subscriptions',
             'resource_name': test_resource_name,
             'project_id': test_project
         },
-        GcpPubsubSubscription,
-        'gcp.pubsub.projects.subscriptions',
-        '//pubsub.googleapis.com/projects/my_project/subscriptions/my_resource'
+        cls=GcpPubsubSubscription,
+        type='gcp.pubsub.projects.subscriptions',
+        name='//pubsub.googleapis.com/projects/my_project/subscriptions/my_resource'
     ),
-    (
-        {
+    ResourceTestCase(
+        input={
             'resource_type': 'pubsub.projects.subscriptions.iam',
             'resource_name': test_resource_name,
             'project_id': test_project
         },
-        GcpPubsubSubscriptionIam,
-        'gcp.pubsub.projects.subscriptions.iam',
-        '//pubsub.googleapis.com/projects/my_project/subscriptions/my_resource'
+        cls=GcpPubsubSubscriptionIam,
+        type='gcp.pubsub.projects.subscriptions.iam',
+        name='//pubsub.googleapis.com/projects/my_project/subscriptions/my_resource'
     ),
-    (
-        {
+    ResourceTestCase(
+        input={
             'resource_type': 'pubsub.projects.topics',
             'resource_name': test_resource_name,
             'project_id': test_project
         },
-        GcpPubsubTopic,
-        'gcp.pubsub.projects.topics',
-        '//pubsub.googleapis.com/projects/my_project/topics/my_resource'
+        cls=GcpPubsubTopic,
+        type='gcp.pubsub.projects.topics',
+        name='//pubsub.googleapis.com/projects/my_project/topics/my_resource'
     ),
-    (
-        {
+    ResourceTestCase(
+        input={
             'resource_type': 'pubsub.projects.topics.iam',
             'resource_name': test_resource_name,
             'project_id': test_project
         },
-        GcpPubsubTopicIam,
-        'gcp.pubsub.projects.topics.iam',
-        '//pubsub.googleapis.com/projects/my_project/topics/my_resource'
+        cls=GcpPubsubTopicIam,
+        type='gcp.pubsub.projects.topics.iam',
+        name='//pubsub.googleapis.com/projects/my_project/topics/my_resource'
     ),
-    (
-        {
+    ResourceTestCase(
+        input={
             'resource_type': 'sqladmin.instances',
             'resource_name': test_resource_name,
             'project_id': test_project
         },
-        GcpSqlInstance,
-        'gcp.sqladmin.instances',
-        '//sql.googleapis.com/projects/my_project/instances/my_resource'
+        cls=GcpSqlInstance,
+        type='gcp.sqladmin.instances',
+        name='//sql.googleapis.com/projects/my_project/instances/my_resource'
     ),
-    (
-        {
+    ResourceTestCase(
+        input={
             'resource_type': 'storage.buckets',
             'resource_name': test_resource_name,
             'project_id': test_project
         },
-        GcpStorageBucket,
-        'gcp.storage.buckets',
-        '//storage.googleapis.com/buckets/my_resource'
+        cls=GcpStorageBucket,
+        type='gcp.storage.buckets',
+        name='//storage.googleapis.com/buckets/my_resource'
     ),
-    (
-        {
+    ResourceTestCase(
+        input={
             'resource_type': 'storage.buckets.iam',
             'resource_name': test_resource_name,
             'project_id': test_project
         },
-        GcpStorageBucketIamPolicy,
-        'gcp.storage.buckets.iam',
-        '//storage.googleapis.com/buckets/my_resource'
+        cls=GcpStorageBucketIamPolicy,
+        type='gcp.storage.buckets.iam',
+        name='//storage.googleapis.com/buckets/my_resource'
     )
 ]
 
 
 @pytest.mark.parametrize(
-    "input,cls,rtype",
-    [(c[0], c[1], c[2]) for c in test_cases],
-    ids=[c[1].__name__ for c in test_cases])
-def test_gcp_resource_factory(input, cls, rtype):
-    r = Resource.factory("gcp", input)
-    assert r.__class__ == cls
-    assert r.type() == rtype
+    "case",
+    test_cases,
+    ids=[case.cls.__name__ for case in test_cases])
+def test_gcp_resource_factory(case):
+    r = Resource.factory("gcp", case.input)
+    assert r.__class__ == case.cls
+    assert r.type() == case.type
 
 
 def test_gcp_resource_factory_invalid():
@@ -162,9 +165,9 @@ def test_gcp_resource_factory_invalid():
 
 
 @pytest.mark.parametrize(
-    "input,frn",
-    [(c[0], c[3]) for c in test_cases],
-    ids=[c[1].__name__ for c in test_cases])
-def test_gcp_full_resource_name(input, frn):
-    r = Resource.factory("gcp", input)
-    assert r.full_resource_name() == frn
+    "case",
+    test_cases,
+    ids=[case.cls.__name__ for case in test_cases])
+def test_gcp_full_resource_name(case):
+    r = Resource.factory("gcp", case.input)
+    assert r.full_resource_name() == case.name

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -22,12 +22,15 @@ from rpe.resources.gcp import GcpSqlInstance
 from rpe.resources.gcp import GcpStorageBucket
 from rpe.resources.gcp import GcpStorageBucketIamPolicy
 
+test_project = "my_project"
+test_resource_name = "my_resource"
+
 test_cases = [
     (
         {
             'resource_type': 'bigquery.datasets',
-            'resource_name': '',
-            'project_id': ''
+            'resource_name': test_resource_name,
+            'project_id': test_project
         },
         GcpBigqueryDataset,
         'gcp.bigquery.datasets'
@@ -35,8 +38,9 @@ test_cases = [
     (
         {
             'resource_type': 'compute.instances',
-            'resource_name': '',
-            'project_id': ''
+            'resource_name': test_resource_name,
+            'resource_location': 'us-central1-a',
+            'project_id': test_project
         },
         GcpComputeInstance,
         'gcp.compute.instances'
@@ -44,8 +48,8 @@ test_cases = [
     (
         {
             'resource_type': 'sqladmin.instances',
-            'resource_name': '',
-            'project_id': ''
+            'resource_name': test_resource_name,
+            'project_id': test_project
         },
         GcpSqlInstance,
         'gcp.sqladmin.instances'
@@ -53,8 +57,8 @@ test_cases = [
     (
         {
             'resource_type': 'storage.buckets',
-            'resource_name': '',
-            'project_id': ''
+            'resource_name': test_resource_name,
+            'project_id': test_project
         },
         GcpStorageBucket,
         'gcp.storage.buckets'
@@ -62,8 +66,8 @@ test_cases = [
     (
         {
             'resource_type': 'storage.buckets.iam',
-            'resource_name': '',
-            'project_id': ''
+            'resource_name': test_resource_name,
+            'project_id': test_project
         },
         GcpStorageBucketIamPolicy,
         'gcp.storage.buckets.iam'

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -18,6 +18,12 @@ import pytest
 from rpe.resources import Resource
 from rpe.resources.gcp import GcpBigqueryDataset
 from rpe.resources.gcp import GcpComputeInstance
+from rpe.resources.gcp import GcpProject
+from rpe.resources.gcp import GcpProjectIam
+from rpe.resources.gcp import GcpPubsubSubscription
+from rpe.resources.gcp import GcpPubsubSubscriptionIam
+from rpe.resources.gcp import GcpPubsubTopic
+from rpe.resources.gcp import GcpPubsubTopicIam
 from rpe.resources.gcp import GcpSqlInstance
 from rpe.resources.gcp import GcpStorageBucket
 from rpe.resources.gcp import GcpStorageBucketIamPolicy
@@ -46,6 +52,66 @@ test_cases = [
         GcpComputeInstance,
         'gcp.compute.instances',
         '//compute.googleapis.com/projects/my_project/zones/us-central1-a/instances/my_resource'
+    ),
+    (
+        {
+            'resource_type': 'cloudresourcemanager.projects',
+            'resource_name': test_project,
+            'project_id': test_project
+        },
+        GcpProject,
+        'gcp.cloudresourcemanager.projects',
+        '//cloudresourcemanager.googleapis.com/projects/my_project'
+    ),
+    (
+        {
+            'resource_type': 'cloudresourcemanager.projects.iam',
+            'resource_name': test_project,
+            'project_id': test_project
+        },
+        GcpProjectIam,
+        'gcp.cloudresourcemanager.projects.iam',
+        '//cloudresourcemanager.googleapis.com/projects/my_project'
+    ),
+    (
+        {
+            'resource_type': 'pubsub.projects.subscriptions',
+            'resource_name': test_resource_name,
+            'project_id': test_project
+        },
+        GcpPubsubSubscription,
+        'gcp.pubsub.projects.subscriptions',
+        '//pubsub.googleapis.com/projects/my_project/subscriptions/my_resource'
+    ),
+    (
+        {
+            'resource_type': 'pubsub.projects.subscriptions.iam',
+            'resource_name': test_resource_name,
+            'project_id': test_project
+        },
+        GcpPubsubSubscriptionIam,
+        'gcp.pubsub.projects.subscriptions.iam',
+        '//pubsub.googleapis.com/projects/my_project/subscriptions/my_resource'
+    ),
+    (
+        {
+            'resource_type': 'pubsub.projects.topics',
+            'resource_name': test_resource_name,
+            'project_id': test_project
+        },
+        GcpPubsubTopic,
+        'gcp.pubsub.projects.topics',
+        '//pubsub.googleapis.com/projects/my_project/topics/my_resource'
+    ),
+    (
+        {
+            'resource_type': 'pubsub.projects.topics.iam',
+            'resource_name': test_resource_name,
+            'project_id': test_project
+        },
+        GcpPubsubTopicIam,
+        'gcp.pubsub.projects.topics.iam',
+        '//pubsub.googleapis.com/projects/my_project/topics/my_resource'
     ),
     (
         {
@@ -93,6 +159,7 @@ def test_gcp_resource_factory(input, cls, rtype):
 def test_gcp_resource_factory_invalid():
     with pytest.raises(AssertionError):
         Resource.factory('gcp', {})
+
 
 @pytest.mark.parametrize(
     "input,frn",

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -33,7 +33,8 @@ test_cases = [
             'project_id': test_project
         },
         GcpBigqueryDataset,
-        'gcp.bigquery.datasets'
+        'gcp.bigquery.datasets',
+        '//bigquery.googleapis.com/projects/my_project/datasets/my_resource'
     ),
     (
         {
@@ -43,7 +44,8 @@ test_cases = [
             'project_id': test_project
         },
         GcpComputeInstance,
-        'gcp.compute.instances'
+        'gcp.compute.instances',
+        '//compute.googleapis.com/projects/my_project/zones/us-central1-a/instances/my_resource'
     ),
     (
         {
@@ -52,7 +54,8 @@ test_cases = [
             'project_id': test_project
         },
         GcpSqlInstance,
-        'gcp.sqladmin.instances'
+        'gcp.sqladmin.instances',
+        '//sql.googleapis.com/projects/my_project/instances/my_resource'
     ),
     (
         {
@@ -61,7 +64,8 @@ test_cases = [
             'project_id': test_project
         },
         GcpStorageBucket,
-        'gcp.storage.buckets'
+        'gcp.storage.buckets',
+        '//storage.googleapis.com/buckets/my_resource'
     ),
     (
         {
@@ -70,15 +74,16 @@ test_cases = [
             'project_id': test_project
         },
         GcpStorageBucketIamPolicy,
-        'gcp.storage.buckets.iam'
+        'gcp.storage.buckets.iam',
+        '//storage.googleapis.com/buckets/my_resource'
     )
 ]
 
 
 @pytest.mark.parametrize(
     "input,cls,rtype",
-    test_cases,
-    ids=[cls.__name__ for (_, cls, _) in test_cases])
+    [(c[0], c[1], c[2]) for c in test_cases],
+    ids=[c[1].__name__ for c in test_cases])
 def test_gcp_resource_factory(input, cls, rtype):
     r = Resource.factory("gcp", input)
     assert r.__class__ == cls
@@ -88,3 +93,11 @@ def test_gcp_resource_factory(input, cls, rtype):
 def test_gcp_resource_factory_invalid():
     with pytest.raises(AssertionError):
         Resource.factory('gcp', {})
+
+@pytest.mark.parametrize(
+    "input,frn",
+    [(c[0], c[3]) for c in test_cases],
+    ids=[c[1].__name__ for c in test_cases])
+def test_gcp_full_resource_name(input, frn):
+    r = Resource.factory("gcp", input)
+    assert r.full_resource_name() == frn


### PR DESCRIPTION
Add function to generate the full resource name on google resources. Also inject the full resource name into resource documents so it can be used during policy evaluation. 

In a future iteration, the policy hierarchy can be flattened out, and policies can be matched and evaluated based on the full resource name, and the OPA glob() function. In order to implement that we will also need to a way to see the asset type (resource, iam_policy) so we don't try to evaluate resource policies against IAM and vice versa