### PR TITLE
Add empty body to GCP project IAM get requests

### DIFF
--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -419,7 +419,8 @@ class GcpProjectIam(GcpProject):
 
     def _get_request_args(self):
         return {
-            'resource': self.resource_data['resource_name']
+            'resource': self.resource_data['resource_name'],
+            'body': {}
         }
 
     def _update_request_args(self, body):


### PR DESCRIPTION
On July 3rd, we started seeing errors with the projects.getIamPolicy request stating that the required parameter `body` was missing. I submitted what we saw, and what I was able to determine, and a guess as to what may have caused the issue here:

https://github.com/googleapis/google-api-python-client/issues/713