### PR TITLE
added dataproc safeguards

### DIFF
--- a/policy/dataproc/common.rego
+++ b/policy/dataproc/common.rego
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 
----
-config:
-  exclusions:
-    labels:
-      forseti-enforcer: disable
-  dataproc:
-    harden_images_project: my-project-id
-    cluster_max_age_ns: 5184000000000000
+package gcp.dataproc.projects.regions.clusters
+
+policies [policy_name] {
+    data.gcp.dataproc.projects.regions.clusters.policy[policy_name]
+}
+
+violations [policy_name] {
+    policy := data.gcp.dataproc.projects.regions.clusters.policy[policy_name]
+    policy.valid = false
+}

--- a/policy/dataproc/hardened_image.rego
+++ b/policy/dataproc/hardened_image.rego
@@ -31,10 +31,7 @@ default valid = false
 
 # Check if hardened image used
 valid = true {
-    image_uri = split(input.config.masterConfig.imageUri,"/")
-
-    #check what project source was used for images
-    image_uri[6] == data.config.dataproc.harden_images_project
+    contains(input.config.masterConfig.imageUri, concat("/",["projects",data.config.dataproc.harden_images_project]))
 }
 
 # Check for a global exclusion based on resource labels

--- a/policy/dataproc/hardened_image.rego
+++ b/policy/dataproc/hardened_image.rego
@@ -1,0 +1,53 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.dataproc.projects.regions.clusters.policy.hardened_image
+
+#####
+# Resource metadata
+#####
+
+labels = input.labels
+
+#####
+# Policy evaluation
+#####
+
+default valid = false
+
+# approved project_id for images is configured in policy/config.yaml - dataproc:harden_images_project
+
+# Check if hardened image used
+valid = true {
+    image_uri = split(input.config.masterConfig.imageUri,"/")
+
+    #check what project source was used for images
+    image_uri[6] == data.config.dataproc.harden_images_project
+}
+
+# Check for a global exclusion based on resource labels
+valid = true {
+  data.exclusions.label_exclude(labels)
+}
+
+#####
+# Remediation
+#####
+
+# Since we cannot remediate it, if policy fails lets end it with "No possible remediation"
+remediate[key] = value {
+  false
+  input[key]=value
+}

--- a/policy/dataproc/hardened_image_test.rego
+++ b/policy/dataproc/hardened_image_test.rego
@@ -1,0 +1,66 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.dataproc.projects.regions.clusters.policy.hardened_image
+
+test_valid_policies {
+  valid with input as {
+   "labels": {
+   },
+   "config": {
+    "masterConfig":{
+      "imageUri": "https://www.googleapis.com/compute/beta/projects/my-project-id/global/images/image_name"
+    }
+   }
+  }
+}
+
+test_valid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+       "masterConfig":{
+         "imageUri": "https://www.googleapis.com/compute/beta/projects/my-project-id/global/images/image_name"
+       }
+     }
+  }
+}
+
+test_invalid_policies {
+  not valid with input as {
+   "labels": {
+   },
+   "config": {
+     "masterConfig":{
+       "imageUri": "https://www.googleapis.com/compute/beta/projects/not-approved-project/global/images/image_name"
+     }
+   }
+  }
+}
+
+test_invalid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+       "masterConfig":{
+         "imageUri": "https://www.googleapis.com/compute/beta/projects/not-approved-project/global/images/image_name"
+       }
+     }
+  }
+}

--- a/policy/dataproc/is_cluster_too_old.rego
+++ b/policy/dataproc/is_cluster_too_old.rego
@@ -1,0 +1,58 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.dataproc.projects.regions.clusters.policy.is_cluster_too_old
+
+#####
+# Resource metadata
+#####
+
+labels = input.labels
+
+#####
+# Policy evaluation
+#####
+
+default valid = false
+
+# Max age for cluster in nanoseconds is configured in policy/config.yaml - dataproc:cluster_max_age_ns
+# by default is equel to 60 days (5184000000000000 ns)
+
+# Check if cluster was created earlier than cluster_max_age_ns
+valid = true {
+    creationTime := [ creationTime | input.statusHistory[i].state == "CREATING"; creationTime := input.statusHistory[i].stateStartTime ]
+    time.now_ns() - time.parse_rfc3339_ns(creationTime[0]) < data.config.dataproc.cluster_max_age_ns
+}
+
+valid = true {
+    #Check creation date if cluster is in CREATING state now (in case of network or other issues it can be hanging for a long time)
+    creationTime := [ creationTime | input.status.state == "CREATING"; creationTime := input.status.stateStartTime ]
+    time.now_ns() - time.parse_rfc3339_ns(creationTime[0]) < data.config.dataproc.cluster_max_age_ns
+}
+
+valid = true {
+  # Also, make sure this resource isn't excluded by label
+  data.exclusions.label_exclude(labels)
+}
+
+#####
+# Remediation
+#####
+
+# Since we cannot remediate it, if policy fails lets end it with "No possible remediation"
+remediate[key] = value {
+  false
+  input[key]=value
+}

--- a/policy/dataproc/is_cluster_too_old_test.rego
+++ b/policy/dataproc/is_cluster_too_old_test.rego
@@ -1,0 +1,48 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.dataproc.projects.regions.clusters.policy.is_cluster_too_old
+
+#as validness depends on time of execution, we can surely test only part with labels
+test_invalid_policies {
+  not valid with input as {
+   "labels": {
+   },
+   "config": {
+     "statusHistory": [
+       {"state": "begin",
+        "stateStartTime": "2017-01-01T01:00:00.000Z"},
+       {"state": "updated",
+        "stateStartTime": "2021-11-11T11:11:11.111Z"}
+     ]
+   }
+  }
+}
+
+test_invalid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+       "statusHistory": [
+         {"state": "begin",
+          "stateStartTime": "2017-01-01T01:00:00.000Z"},
+         {"state": "updated",
+          "stateStartTime": "2021-11-11T11:11:11.111Z"}
+       ]
+     }
+  }
+}

--- a/policy/dataproc/job_logging.rego
+++ b/policy/dataproc/job_logging.rego
@@ -1,0 +1,49 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.dataproc.projects.regions.clusters.policy.job_logging
+
+#####
+# Resource metadata
+#####
+
+labels = input.labels
+
+#####
+# Policy evaluation
+#####
+
+default valid = false
+
+valid = true {
+  input.config.softwareConfig.properties["dataproc:dataproc.logging.stackdriver.enable"] == "true"
+  input.config.softwareConfig.properties["dataproc:dataproc.logging.stackdriver.job.driver.enable"] == "true"
+  input.config.softwareConfig.properties["dataproc:jobs.file-backed-output.enable"] == "true"
+}
+
+# Check for a global exclusion based on resource labels
+valid = true {
+  data.exclusions.label_exclude(labels)
+}
+
+#####
+# Remediation
+#####
+
+# Since we cannot remediate it, if policy fails lets end it with "No possible remediation"
+remediate[key] = value {
+  false
+  input[key]=value
+}

--- a/policy/dataproc/job_logging_test.rego
+++ b/policy/dataproc/job_logging_test.rego
@@ -1,0 +1,86 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.dataproc.projects.regions.clusters.policy.job_logging
+
+test_valid_policies {
+  valid with input as {
+   "labels": {
+   },
+   "config": {
+    "softwareConfig":{
+      "properties":[
+         {
+            "dataproc:dataproc.logging.stackdriver.enable": "true",
+            "dataproc:dataproc.logging.stackdriver.job.driver.enable": "true",
+            "dataproc:jobs.file-backed-output.enable": "true"
+         }
+      ]
+    }
+   }
+  }
+}
+
+test_valid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+      "softwareConfig":{
+        "properties":[
+           {
+             "dataproc:dataproc.logging.stackdriver.enable": "true",
+             "dataproc:dataproc.logging.stackdriver.job.driver.enable": "true",
+             "dataproc:jobs.file-backed-output.enable": "true"
+           }
+        ]
+      }
+     }
+  }
+}
+
+test_invalid_policies {
+  not valid with input as {
+   "labels": {
+   },
+   "config": {
+    "softwareConfig":{
+      "properties":[
+         {
+            "dataproc:dataproc.logging.stackdriver.enable": "true"
+         }
+      ]
+    }
+   }
+  }
+}
+
+test_invalid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+      "softwareConfig":{
+        "properties":[
+           {
+              "dataproc:dataproc.logging.stackdriver.enable": "true"
+           }
+        ]
+      }
+     }
+  }
+}

--- a/policy/dataproc/job_logging_test.rego
+++ b/policy/dataproc/job_logging_test.rego
@@ -21,13 +21,11 @@ test_valid_policies {
    },
    "config": {
     "softwareConfig":{
-      "properties":[
-         {
+      "properties":{
             "dataproc:dataproc.logging.stackdriver.enable": "true",
             "dataproc:dataproc.logging.stackdriver.job.driver.enable": "true",
             "dataproc:jobs.file-backed-output.enable": "true"
-         }
-      ]
+      }
     }
    }
   }
@@ -40,13 +38,11 @@ test_valid_policies_with_override {
      },
      "config": {
       "softwareConfig":{
-        "properties":[
-           {
+        "properties":{
              "dataproc:dataproc.logging.stackdriver.enable": "true",
              "dataproc:dataproc.logging.stackdriver.job.driver.enable": "true",
              "dataproc:jobs.file-backed-output.enable": "true"
-           }
-        ]
+        }
       }
      }
   }
@@ -58,11 +54,9 @@ test_invalid_policies {
    },
    "config": {
     "softwareConfig":{
-      "properties":[
-         {
+      "properties":{
             "dataproc:dataproc.logging.stackdriver.enable": "true"
-         }
-      ]
+      }
     }
    }
   }
@@ -75,11 +69,9 @@ test_invalid_policies_with_override {
      },
      "config": {
       "softwareConfig":{
-        "properties":[
-           {
+        "properties":{
               "dataproc:dataproc.logging.stackdriver.enable": "true"
-           }
-        ]
+        }
       }
      }
   }

--- a/policy/dataproc/kerberos.rego
+++ b/policy/dataproc/kerberos.rego
@@ -13,11 +13,35 @@
 # limitations under the License.
 
 
----
-config:
-  exclusions:
-    labels:
-      forseti-enforcer: disable
-  dataproc:
-    harden_images_project: my-project-id
-    cluster_max_age_ns: 5184000000000000
+package gcp.dataproc.projects.regions.clusters.policy.kerberos
+
+#####
+# Resource metadata
+#####
+
+labels = input.labels
+
+#####
+# Policy evaluation
+#####
+
+default valid = false
+
+valid = true {
+  input.config.securityConfig.kerberosConfig.enableKerberos == true
+}
+
+# Check for a global exclusion based on resource labels
+valid = true {
+  data.exclusions.label_exclude(labels)
+}
+
+#####
+# Remediation
+#####
+
+# Since we cannot remediate it, if policy fails lets end it with "No possible remediation"
+remediate[key] = value {
+  false
+  input[key]=value
+}

--- a/policy/dataproc/kerberos_test.rego
+++ b/policy/dataproc/kerberos_test.rego
@@ -22,7 +22,7 @@ test_valid_policies {
    "config": {
     "securityConfig":{
       "kerberosConfig": {
-        "enableKerberos": "true"
+        "enableKerberos": true
       }
     }
    }
@@ -37,7 +37,7 @@ test_valid_policies_with_override {
      "config": {
        "securityConfig":{
          "kerberosConfig": {
-           "enableKerberos": "true"
+           "enableKerberos": true
          }
        }
      }
@@ -51,7 +51,7 @@ test_invalid_policies {
    "config": {
      "securityConfig":{
        "kerberosConfig": {
-         "enableKerberos": "false"
+         "enableKerberos": false
        }
      }
    }
@@ -66,7 +66,7 @@ test_invalid_policies_with_override {
      "config": {
        "securityConfig":{
          "kerberosConfig": {
-           "enableKerberos": "false"
+           "enableKerberos": false
          }
        }
      }

--- a/policy/dataproc/kerberos_test.rego
+++ b/policy/dataproc/kerberos_test.rego
@@ -1,0 +1,74 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.dataproc.projects.regions.clusters.policy.kerberos
+
+test_valid_policies {
+  valid with input as {
+   "labels": {
+   },
+   "config": {
+    "securityConfig":{
+      "kerberosConfig": {
+        "enableKerberos": "true"
+      }
+    }
+   }
+  }
+}
+
+test_valid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+       "securityConfig":{
+         "kerberosConfig": {
+           "enableKerberos": "true"
+         }
+       }
+     }
+  }
+}
+
+test_invalid_policies {
+  not valid with input as {
+   "labels": {
+   },
+   "config": {
+     "securityConfig":{
+       "kerberosConfig": {
+         "enableKerberos": "false"
+       }
+     }
+   }
+  }
+}
+
+test_invalid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+       "securityConfig":{
+         "kerberosConfig": {
+           "enableKerberos": "false"
+         }
+       }
+     }
+  }
+}

--- a/policy/dataproc/not_default_service_account.rego
+++ b/policy/dataproc/not_default_service_account.rego
@@ -13,11 +13,36 @@
 # limitations under the License.
 
 
----
-config:
-  exclusions:
-    labels:
-      forseti-enforcer: disable
-  dataproc:
-    harden_images_project: my-project-id
-    cluster_max_age_ns: 5184000000000000
+package gcp.dataproc.projects.regions.clusters.policy.not_default_serviceaccount
+
+#####
+# Resource metadata
+#####
+
+labels = input.labels
+
+#####
+# Policy evaluation
+#####
+
+default valid = false
+
+# Check if service account is used, if field is not set - default account was used
+valid = true {
+  input.config.gceClusterConfig.serviceAccount
+}
+
+# Check for a global exclusion based on resource labels
+valid = true {
+  data.exclusions.label_exclude(labels)
+}
+
+#####
+# Remediation
+#####
+
+# Since we cannot remediate it, if policy fails lets end it with "No possible remediation"
+remediate[key] = value {
+  false
+  input[key]=value
+}

--- a/policy/dataproc/not_default_service_account_test.rego
+++ b/policy/dataproc/not_default_service_account_test.rego
@@ -1,0 +1,64 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.dataproc.projects.regions.clusters.policy.not_default_serviceaccount
+
+test_valid_policies {
+  valid with input as {
+   "labels": {
+   },
+   "config": {
+      "gceClusterConfig":{
+        "serviceAccount": "dataproc_sa@my-project-id.iam.gserviceaccount.com"
+      }
+   }
+  }
+}
+
+test_valid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+       "gceClusterConfig":{
+         "serviceAccount": "dataproc_sa@my-project-id.iam.gserviceaccount.com"
+       }
+     }
+  }
+}
+
+test_invalid_policies {
+  not valid with input as {
+   "labels": {
+   },
+   "config": {
+     "gceClusterConfig":{
+     }
+   }
+  }
+}
+
+test_invalid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+       "gceClusterConfig":{
+       }
+     }
+  }
+}

--- a/policy/dataproc/stackdriver_logging.rego
+++ b/policy/dataproc/stackdriver_logging.rego
@@ -13,11 +13,35 @@
 # limitations under the License.
 
 
----
-config:
-  exclusions:
-    labels:
-      forseti-enforcer: disable
-  dataproc:
-    harden_images_project: my-project-id
-    cluster_max_age_ns: 5184000000000000
+package gcp.dataproc.projects.regions.clusters.policy.stackdriver_logging
+
+#####
+# Resource metadata
+#####
+
+labels = input.labels
+
+#####
+# Policy evaluation
+#####
+
+default valid = false
+
+valid = true {
+  input.config.softwareConfig.properties["dataproc:dataproc.logging.stackdriver.enable"] == "true"
+}
+
+# Check for a global exclusion based on resource labels
+valid = true {
+  data.exclusions.label_exclude(labels)
+}
+
+#####
+# Remediation
+#####
+
+# Since we cannot remediate it, if policy fails lets end it with "No possible remediation"
+remediate[key] = value {
+  false
+  input[key]=value
+}

--- a/policy/dataproc/stackdriver_logging_test.rego
+++ b/policy/dataproc/stackdriver_logging_test.rego
@@ -1,0 +1,82 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.dataproc.projects.regions.clusters.policy.stackdriver_logging
+
+test_valid_policies {
+  valid with input as {
+   "labels": {
+   },
+   "config": {
+    "softwareConfig":{
+      "properties":[
+         {
+            "dataproc:dataproc.logging.stackdriver.enable": "true"
+         }
+      ]
+    }
+   }
+  }
+}
+
+test_valid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+      "softwareConfig":{
+        "properties":[
+           {
+              "dataproc:dataproc.logging.stackdriver.enable": "true"
+           }
+        ]
+      }
+     }
+  }
+}
+
+test_invalid_policies {
+  not valid with input as {
+   "labels": {
+   },
+   "config": {
+    "softwareConfig":{
+      "properties":[
+         {
+            "dataproc:dataproc.logging.stackdriver.enable": "false"
+         }
+      ]
+    }
+   }
+  }
+}
+
+test_invalid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+      "softwareConfig":{
+        "properties":[
+           {
+              "dataproc:dataproc.logging.stackdriver.enable": "false"
+           }
+        ]
+      }
+     }
+  }
+}

--- a/policy/dataproc/stackdriver_logging_test.rego
+++ b/policy/dataproc/stackdriver_logging_test.rego
@@ -21,11 +21,9 @@ test_valid_policies {
    },
    "config": {
     "softwareConfig":{
-      "properties":[
-         {
-            "dataproc:dataproc.logging.stackdriver.enable": "true"
-         }
-      ]
+      "properties":{
+          "dataproc:dataproc.logging.stackdriver.enable": "true"
+       }
     }
    }
   }
@@ -38,11 +36,9 @@ test_valid_policies_with_override {
      },
      "config": {
       "softwareConfig":{
-        "properties":[
-           {
+        "properties":{
               "dataproc:dataproc.logging.stackdriver.enable": "true"
-           }
-        ]
+        }
       }
      }
   }
@@ -54,11 +50,9 @@ test_invalid_policies {
    },
    "config": {
     "softwareConfig":{
-      "properties":[
-         {
+      "properties":{
             "dataproc:dataproc.logging.stackdriver.enable": "false"
-         }
-      ]
+      }
     }
    }
   }
@@ -71,11 +65,9 @@ test_invalid_policies_with_override {
      },
      "config": {
       "softwareConfig":{
-        "properties":[
-           {
+        "properties":{
               "dataproc:dataproc.logging.stackdriver.enable": "false"
-           }
-        ]
+        }
       }
      }
   }

--- a/policy/dataproc/yarn_logging.rego
+++ b/policy/dataproc/yarn_logging.rego
@@ -1,0 +1,49 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.dataproc.projects.regions.clusters.policy.yarn_logging
+
+#####
+# Resource metadata
+#####
+
+labels = input.labels
+
+#####
+# Policy evaluation
+#####
+
+default valid = false
+
+valid = true {
+  input.config.softwareConfig.properties["dataproc:dataproc.logging.stackdriver.enable"] == "true"
+  input.config.softwareConfig.properties["dataproc:dataproc.logging.stackdriver.job.yarn.container.enable"] == "true"
+  input.config.softwareConfig.properties["dataproc:jobs.file-backed-output.enable"] == "true"
+}
+
+# Check for a global exclusion based on resource labels
+valid = true {
+  data.exclusions.label_exclude(labels)
+}
+
+#####
+# Remediation
+#####
+
+# Since we cannot remediate it, if policy fails lets end it with "No possible remediation"
+remediate[key] = value {
+  false
+  input[key]=value
+}

--- a/policy/dataproc/yarn_logging_test.rego
+++ b/policy/dataproc/yarn_logging_test.rego
@@ -1,0 +1,88 @@
+# Copyright 2019 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+package gcp.dataproc.projects.regions.clusters.policy.yarn_logging
+
+test_valid_policies {
+  valid with input as {
+   "labels": {
+   },
+   "config": {
+    "softwareConfig":{
+      "properties":[
+         {
+            "dataproc:dataproc.logging.stackdriver.enable": "true",
+            "dataproc:dataproc.logging.stackdriver.job.yarn.container.enable": "true",
+            "dataproc:jobs.file-backed-output.enable": "true"
+         }
+      ]
+    }
+   }
+  }
+}
+
+test_valid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+      "softwareConfig":{
+        "properties":[
+           {
+              "dataproc:dataproc.logging.stackdriver.enable": "true",
+              "dataproc:dataproc.logging.stackdriver.job.yarn.container.enable": "true",
+              "dataproc:jobs.file-backed-output.enable": "true"
+           }
+        ]
+      }
+     }
+  }
+}
+
+test_invalid_policies {
+  not valid with input as {
+   "labels": {
+   },
+   "config": {
+    "softwareConfig":{
+      "properties":[
+         {
+            "dataproc:dataproc.logging.stackdriver.enable": "true",
+            "dataproc:jobs.file-backed-output.enable": "true"
+         }
+      ]
+    }
+   }
+  }
+}
+
+test_invalid_policies_with_override {
+  valid with input as {
+     "labels": {
+        "forseti-enforcer": "disable",
+     },
+     "config": {
+      "softwareConfig":{
+        "properties":[
+           {
+              "dataproc:dataproc.logging.stackdriver.enable": "true",
+              "dataproc:jobs.file-backed-output.enable": "true"
+           }
+        ]
+      }
+     }
+  }
+}

--- a/policy/dataproc/yarn_logging_test.rego
+++ b/policy/dataproc/yarn_logging_test.rego
@@ -21,13 +21,11 @@ test_valid_policies {
    },
    "config": {
     "softwareConfig":{
-      "properties":[
-         {
+      "properties":{
             "dataproc:dataproc.logging.stackdriver.enable": "true",
             "dataproc:dataproc.logging.stackdriver.job.yarn.container.enable": "true",
             "dataproc:jobs.file-backed-output.enable": "true"
-         }
-      ]
+      }
     }
    }
   }
@@ -40,13 +38,11 @@ test_valid_policies_with_override {
      },
      "config": {
       "softwareConfig":{
-        "properties":[
-           {
+        "properties":{
               "dataproc:dataproc.logging.stackdriver.enable": "true",
               "dataproc:dataproc.logging.stackdriver.job.yarn.container.enable": "true",
               "dataproc:jobs.file-backed-output.enable": "true"
-           }
-        ]
+        }
       }
      }
   }
@@ -58,12 +54,10 @@ test_invalid_policies {
    },
    "config": {
     "softwareConfig":{
-      "properties":[
-         {
+      "properties":{
             "dataproc:dataproc.logging.stackdriver.enable": "true",
             "dataproc:jobs.file-backed-output.enable": "true"
-         }
-      ]
+      }
     }
    }
   }
@@ -76,12 +70,10 @@ test_invalid_policies_with_override {
      },
      "config": {
       "softwareConfig":{
-        "properties":[
-           {
+        "properties":{
               "dataproc:dataproc.logging.stackdriver.enable": "true",
               "dataproc:jobs.file-backed-output.enable": "true"
-           }
-        ]
+        }
       }
      }
   }

--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -85,6 +85,7 @@ class GoogleAPIResource(Resource):
             'compute.firewalls': GcpComputeFirewall,
             'cloudresourcemanager.projects': GcpProject,
             'cloudresourcemanager.projects.iam': GcpProjectIam,
+            'dataproc.clusters': GcpDataprocCluster,
             'pubsub.projects.subscriptions': GcpPubsubSubscription,
             'pubsub.projects.subscriptions.iam': GcpPubsubSubscriptionIam,
             'pubsub.projects.topics': GcpPubsubTopic,
@@ -389,6 +390,26 @@ class GcpComputeFirewall(GoogleAPIResource):
             'firewall': self.resource_data['resource_name'],
             'project': self.resource_data['project_id'],
             'body': body
+        }
+
+class GcpDataprocCluster(GoogleAPIResource):
+    service_name = "dataproc"
+    resource_path = "projects.regions.clusters"
+    update_method = "patch"
+    version = "v1beta2"
+
+    def _get_request_args(self):
+        return {
+            'projectId': self.resource_data['project_id'],
+            'region': self.resource_data['resource_location'],
+            'clusterName': self.resource_data['resource_name']
+        }
+
+    def _update_request_args(self, body):
+        return {
+            'projectId': self.resource_data['project_id'],
+            'region': self.resource_data['resource_location'],
+            'clusterName': self.resource_data['resource_name']
         }
 
 class GcpPubsubSubscription(GoogleAPIResource):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -22,6 +22,7 @@ from rpe.resources.gcp import GcpBigqueryDataset
 from rpe.resources.gcp import GcpCloudFunction
 from rpe.resources.gcp import GcpCloudFunctionIam
 from rpe.resources.gcp import GcpComputeInstance
+from rpe.resources.gcp import GcpDataprocCluster
 from rpe.resources.gcp import GcpProject
 from rpe.resources.gcp import GcpProjectIam
 from rpe.resources.gcp import GcpPubsubSubscription
@@ -112,6 +113,17 @@ test_cases = [
         cls=GcpProjectIam,
         type='gcp.cloudresourcemanager.projects.iam',
         name='//cloudresourcemanager.googleapis.com/projects/my_project'
+    ),
+    ResourceTestCase(
+        input={
+            'resource_type': 'dataproc.clusters',
+            'resource_name': test_resource_name,
+            'resource_location': 'global',
+            'project_id': test_project
+        },
+        cls=GcpDataprocCluster,
+        type='gcp.dataproc.projects.regions.clusters',
+        name='//dataproc.googleapis.com/projects/my_project/regions/global/clusters/my_resource'
     ),
     ResourceTestCase(
         input={


### PR DESCRIPTION
Added policies for dataproc:
- Cluster is using a hardened image
- Stackdriver logging is enabled
- YARN container logging is enabled
- Job logging is enabled
- Secure Mode via Kerberos is enabled
- Is cluster older than 60 days
- Cluster is deployed using a non-default identity