### PR TITLE
AppEngine instance waiter, and disable debug policy update

### DIFF
--- a/policy/appengine/debug.rego
+++ b/policy/appengine/debug.rego
@@ -35,8 +35,21 @@ valid = false {
  # Remediation
  #####
 
-  # Since we cannot remediate it, debug mode is read-only and its on the instance. Lets end it with "No possible remediation"
- remediate[key] = value {
-   input.vmDebugEnabled == false
-   input[key]=value
- }
+remediate = {
+  "_remediation_spec": "v2beta1",
+  "steps": [
+    delete_instance
+  ]
+}
+
+delete_instance = {
+    "method": "delete",
+    "params": {
+        "appsId": name_parts[1],
+        "servicesId": name_parts[3],
+        "versionsId": name_parts[5],
+        "instancesId": name_parts[7]
+    }
+}
+
+name_parts = split(input.name, "/")

--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -264,6 +264,8 @@ class GcpAppEngineInstance(GoogleAPIResource):
     service_name = "appengine"
     resource_path = "apps.services.versions.instances"
     version = "v1"
+    readiness_key = 'vmStatus'
+    readiness_value = 'RUNNING'
     update_method = "debug"
 
     cai_type = None             # unknown


### PR DESCRIPTION
Add a readiness waiter for appengine instances to avoid evaluation when there is an ongoing operation on the instance. Also update the appengine instance debug policy to delete the instance (the documented way to disable debug mode on an instance)