### PR TITLE
Add fix for cloudsql full resource names

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -242,7 +242,7 @@ test_cases = [
         },
         cls=GcpSqlInstance,
         type='gcp.sqladmin.instances',
-        name='//sql.googleapis.com/projects/my_project/instances/my_resource'
+        name='//cloudsql.googleapis.com/projects/my_project/instances/my_resource'
     ),
     ResourceTestCase(
         input={


### PR DESCRIPTION
CloudSQLs discovery document started returning urls that look like `https://sqladmin.googleapis.com/sql/v1beta4...`

Also the bigquery request.uri is now returning unformatted urls like this `https://bigquery.googleapis.com/bigquery/v2/projects/%7Bproject-id%7D/datasets/%7BdataSet%7D?alt=json`