### PR TITLE
Add support for CAI's types

### DIFF
--- a/rpe/exceptions.py
+++ b/rpe/exceptions.py
@@ -46,6 +46,9 @@ class NoPossibleRemediation(Exception):
     pass
 
 
+class ResourceException(Exception):
+    pass
+
 class UnsupportedRemediationSpec(Exception):
     pass
 

--- a/rpe/resources/base.py
+++ b/rpe/resources/base.py
@@ -19,7 +19,7 @@ from abc import ABC, abstractmethod
 class Resource(ABC):
 
     @staticmethod
-    def factory(platform, resource_data, **kargs):
+    def factory(platform, **kargs):
         """ Return a resource from the appropriate platform """
         from .gcp import GoogleAPIResource
 
@@ -29,7 +29,6 @@ class Resource(ABC):
 
         try:
             resource = resource_platform_map[platform].factory(
-                resource_data,
                 **kargs
             )
         except KeyError:

--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -912,20 +912,18 @@ class GcpStorageBucket(GoogleAPIResource):
     resource_path = "buckets"
     version = "v1"
 
-    required_resource_data = ['name', 'project_id']
+    required_resource_data = ['name']
 
     cai_type = "storage.googleapis.com/Bucket"
 
     def _get_request_args(self):
         return {
             'bucket': self.resource.name,
-            'userProject': self.resource.project_id
         }
 
     def _update_request_args(self, body):
         return {
             'bucket': self.resource.name,
-            'userProject': self.resource.project_id,
             'body': body
         }
 

--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -27,25 +27,6 @@ from googleapiclienthelpers.waiter import Waiter
 # client for resource manager, will be lazy created later
 resource_manager_projects = None
 
-
-class _ResourceData:
-    ''' Simple class to store resource attributes for easy access '''
-
-    def __init__(self, **kwargs):
-        self._data = kwargs
-
-    # Allow access to resource kwargs
-    def __getattr__(self, name):
-        if name in self._data:
-            return self._data.get(name)
-        else:
-            raise AttributeError
-
-    @property
-    def data(self):
-        return self._data.copy()
-
-
 class GoogleAPIResource(Resource):
 
     # Names of the get and update methods. Most are the same but override in
@@ -72,9 +53,6 @@ class GoogleAPIResource(Resource):
         self._resource_data = resource_data
         self._validate_resource_data()
 
-        # Store resource information
-        self.resource = _ResourceData(**resource_data)
-
         # Store the client kwargs to pass to any new clients
         self._client_kwargs = client_kwargs
 
@@ -98,7 +76,7 @@ class GoogleAPIResource(Resource):
 
             self.parent_resource = self.parent_cls(
                 client_kwargs = self._client_kwargs,
-                **self.resource.data
+                **self._resource_data.copy()
             )
 
         self._ancestry = None
@@ -415,7 +393,7 @@ class GoogleAPIResource(Resource):
                 )
 
             self._ancestry = resource_manager_projects.getAncestry(
-                projectId=self.resource.project_id
+                projectId=self._resource_data['project_id']
             ).execute()
         except Exception:
             # This call is best-effort. Any failures should be caught
@@ -439,18 +417,18 @@ class GcpAppEngineInstance(GoogleAPIResource):
 
     def _get_request_args(self):
         return {
-            'appsId': self.resource.app,
-            'servicesId': self.resource.service,
-            'versionsId': self.resource.version,
-            'instancesId': self.resource.name
+            'appsId': self._resource_data['app'],
+            'servicesId': self._resource_data['service'],
+            'versionsId': self._resource_data['version'],
+            'instancesId': self._resource_data['name']
         }
 
     def _update_request_args(self, body):
         return {
-            'appsId': self.resource.app,
-            'servicesId': self.resource.service,
-            'versionsId': self.resource.version,
-            'instancesId': self.resource.name
+            'appsId': self._resource_data['app'],
+            'servicesId': self._resource_data['service'],
+            'versionsId': self._resource_data['version'],
+            'instancesId': self._resource_data['name']
         }
 
 
@@ -466,14 +444,14 @@ class GcpBigqueryDataset(GoogleAPIResource):
 
     def _get_request_args(self):
         return {
-            'datasetId': self.resource.name,
-            'projectId': self.resource.project_id
+            'datasetId': self._resource_data['name'],
+            'projectId': self._resource_data['project_id']
         }
 
     def _update_request_args(self, body):
         return {
-            'datasetId': self.resource.name,
-            'projectId': self.resource.project_id,
+            'datasetId': self._resource_data['name'],
+            'projectId': self._resource_data['project_id'],
             'body': body
         }
 
@@ -494,16 +472,16 @@ class GcpBigtableInstance(GoogleAPIResource):
     def _get_request_args(self):
         return {
             'name': 'projects/{}/instances/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             ),
         }
 
     def _update_request_args(self, body):
         return {
             'name': 'projects/{}/instances/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             ),
             'body': body,
             'updateMask': 'labels,displayName,type'
@@ -524,16 +502,16 @@ class GcpBigtableInstanceIam(GcpBigtableInstance):
     def _get_request_args(self):
         return {
             'resource': 'projects/{}/instances/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             ),
         }
 
     def _update_request_args(self, body):
         return {
             'resource': 'projects/{}/instances/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             ),
             'body': {
                 'policy': body
@@ -555,18 +533,18 @@ class GcpCloudFunction(GoogleAPIResource):
     def _get_request_args(self):
         return {
             'name': 'projects/{}/locations/{}/functions/{}'.format(
-                self.resource.project_id,
-                self.resource.location,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['location'],
+                self._resource_data['name']
             ),
         }
 
     def _update_request_args(self, body):
         return {
             'name': 'projects/{}/locations/{}/functions/{}'.format(
-                self.resource.project_id,
-                self.resource.location,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['location'],
+                self._resource_data['name']
             ),
             'body': body
         }
@@ -584,18 +562,18 @@ class GcpCloudFunctionIam(GcpCloudFunction):
     def _get_request_args(self):
         return {
             'resource': 'projects/{}/locations/{}/functions/{}'.format(
-                self.resource.project_id,
-                self.resource.location,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['location'],
+                self._resource_data['name']
             ),
         }
 
     def _update_request_args(self, body):
         return {
             'resource': 'projects/{}/locations/{}/functions/{}'.format(
-                self.resource.project_id,
-                self.resource.location,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['location'],
+                self._resource_data['name']
             ),
             'body': {
                 'policy': body
@@ -615,16 +593,16 @@ class GcpComputeInstance(GoogleAPIResource):
 
     def _get_request_args(self):
         return {
-            'instance': self.resource.name,
-            'zone': self.resource.location,
-            'project': self.resource.project_id
+            'instance': self._resource_data['name'],
+            'zone': self._resource_data['location'],
+            'project': self._resource_data['project_id']
         }
 
     def _update_request_args(self, body):
         return {
-            'instance': self.resource.name,
-            'zone': self.resource.location,
-            'project': self.resource.project_id
+            'instance': self._resource_data['name'],
+            'zone': self._resource_data['location'],
+            'project': self._resource_data['project_id']
         }
 
 
@@ -640,16 +618,16 @@ class GcpComputeDisks(GoogleAPIResource):
 
     def _get_request_args(self):
         return {
-            'project': self.resource.project_id,
-            'zone': self.resource.location,
-            'disk': self.resource.name
+            'project': self._resource_data['project_id'],
+            'zone': self._resource_data['location'],
+            'disk': self._resource_data['name']
         }
 
     def _update_request_args(self, body):
         return {
-            'project': self.resource.project_id,
-            'zone': self.resource.location,
-            'disk': self.resource.name
+            'project': self._resource_data['project_id'],
+            'zone': self._resource_data['location'],
+            'disk': self._resource_data['name']
         }
 
 
@@ -666,16 +644,16 @@ class GcpComputeSubnetwork(GoogleAPIResource):
 
     def _get_request_args(self):
         return {
-            'project': self.resource.project_id,
-            'region': self.resource.location,
-            'subnetwork': self.resource.name
+            'project': self._resource_data['project_id'],
+            'region': self._resource_data['location'],
+            'subnetwork': self._resource_data['name']
         }
 
     def _update_request_args(self, body):
         return {
-            'project': self.resource.project_id,
-            'region': self.resource.location,
-            'subnetwork': self.resource.name,
+            'project': self._resource_data['project_id'],
+            'region': self._resource_data['location'],
+            'subnetwork': self._resource_data['name'],
             'body': body
         }
 
@@ -693,14 +671,14 @@ class GcpComputeFirewall(GoogleAPIResource):
 
     def _get_request_args(self):
         return {
-            'firewall': self.resource.name,
-            'project': self.resource.project_id
+            'firewall': self._resource_data['name'],
+            'project': self._resource_data['project_id']
         }
 
     def _update_request_args(self, body):
         return {
-            'firewall': self.resource.name,
-            'project': self.resource.project_id,
+            'firewall': self._resource_data['name'],
+            'project': self._resource_data['project_id'],
             'body': body
         }
 
@@ -717,16 +695,16 @@ class GcpDataprocCluster(GoogleAPIResource):
 
     def _get_request_args(self):
         return {
-            'projectId': self.resource.project_id,
-            'region': self.resource.location,
-            'clusterName': self.resource.name
+            'projectId': self._resource_data['project_id'],
+            'region': self._resource_data['location'],
+            'clusterName': self._resource_data['name']
         }
 
     def _update_request_args(self, body):
         return {
-            'projectId': self.resource.project_id,
-            'region': self.resource.location,
-            'clusterName': self.resource.name
+            'projectId': self._resource_data['project_id'],
+            'region': self._resource_data['location'],
+            'clusterName': self._resource_data['name']
         }
 
 
@@ -745,18 +723,18 @@ class GcpGkeCluster(GoogleAPIResource):
     def _get_request_args(self):
         return {
             'name': 'projects/{}/locations/{}/clusters/{}'.format(
-                self.resource.project_id,
-                self.resource.location,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['location'],
+                self._resource_data['name']
             )
         }
 
     def _update_request_args(self, body):
         return {
             'name': 'projects/{}/locations/{}/clusters/{}'.format(
-                self.resource.project_id,
-                self.resource.location,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['location'],
+                self._resource_data['name']
             ),
             'body': body
         }
@@ -777,20 +755,20 @@ class GcpGkeClusterNodepool(GoogleAPIResource):
     def _get_request_args(self):
         return {
             'name': 'projects/{}/locations/{}/clusters/{}/nodePools/{}'.format(
-                self.resource.project_id,
-                self.resource.location,
-                self.resource.cluster,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['location'],
+                self._resource_data['cluster'],
+                self._resource_data['name']
             )
         }
 
     def _update_request_args(self, body):
         return {
             'name': 'projects/{}/locations/{}/clusters/{}/nodePools/{}'.format(
-                self.resource.project_id,
-                self.resource.location,
-                self.resource.cluster,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['location'],
+                self._resource_data['cluster'],
+                self._resource_data['name']
             ),
             'body': body
         }
@@ -810,16 +788,16 @@ class GcpPubsubSubscription(GoogleAPIResource):
     def _get_request_args(self):
         return {
             'subscription': 'projects/{}/subscriptions/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             )
         }
 
     def _update_request_args(self, body):
         return {
             'name': 'projects/{}/subscriptions/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             ),
             'body': {
                 'subscription': body,
@@ -840,16 +818,16 @@ class GcpPubsubSubscriptionIam(GcpPubsubSubscription):
     def _get_request_args(self):
         return {
             'resource': 'projects/{}/subscriptions/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             )
         }
 
     def _update_request_args(self, body):
         return {
             'resource': 'projects/{}/subscriptions/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             ),
             'body': {
                 'policy': body
@@ -871,16 +849,16 @@ class GcpPubsubTopic(GoogleAPIResource):
     def _get_request_args(self):
         return {
             'topic': 'projects/{}/topics/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             )
         }
 
     def _update_request_args(self, body):
         return {
             'name': 'projects/{}/topics/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             ),
             'body': {
                 'topic': body,
@@ -902,16 +880,16 @@ class GcpPubsubTopicIam(GcpPubsubTopic):
     def _get_request_args(self):
         return {
             'resource': 'projects/{}/topics/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             )
         }
 
     def _update_request_args(self, body):
         return {
             'resource': 'projects/{}/topics/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             ),
             'body': {
                 'policy': body
@@ -931,12 +909,12 @@ class GcpStorageBucket(GoogleAPIResource):
 
     def _get_request_args(self):
         return {
-            'bucket': self.resource.name,
+            'bucket': self._resource_data['name'],
         }
 
     def _update_request_args(self, body):
         return {
-            'bucket': self.resource.name,
+            'bucket': self._resource_data['name'],
             'body': body
         }
 
@@ -961,14 +939,14 @@ class GcpSqlInstance(GoogleAPIResource):
 
     def _get_request_args(self):
         return {
-            'instance': self.resource.name,
-            'project': self.resource.project_id
+            'instance': self._resource_data['name'],
+            'project': self._resource_data['project_id']
         }
 
     def _update_request_args(self, body):
         return {
-            'instance': self.resource.name,
-            'project': self.resource.project_id,
+            'instance': self._resource_data['name'],
+            'project': self._resource_data['project_id'],
             'body': body
         }
 
@@ -983,12 +961,12 @@ class GcpProject(GoogleAPIResource):
 
     def _get_request_args(self):
         return {
-            'projectId': self.resource.name
+            'projectId': self._resource_data['name']
         }
 
     def _update_request_args(self, body):
         return {
-            'projectId': self.resource.name,
+            'projectId': self._resource_data['name'],
             'body': body
         }
 
@@ -1002,13 +980,13 @@ class GcpProjectIam(GcpProject):
 
     def _get_request_args(self):
         return {
-            'resource': self.resource.name,
+            'resource': self._resource_data['name'],
             'body': {}
         }
 
     def _update_request_args(self, body):
         return {
-            'resource': self.resource.name,
+            'resource': self._resource_data['name'],
             'body': {
                 'policy': body,
                 'updateMask': "bindings,etag,auditConfigs"
@@ -1029,8 +1007,8 @@ class GcpProjectService(GoogleAPIResource):
     def _get_request_args(self):
         return {
             'name': 'projects/{}/services/{}'.format(
-                self.resource.project_id,
-                self.resource.name
+                self._resource_data['project_id'],
+                self._resource_data['name']
             )
         }
 

--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -317,8 +317,21 @@ class GoogleAPIResource(Resource):
             path_segments[-1] = path_segments[-1].split(":")[0]
 
         # Annoying resource-specific fixes
+
+        # The url for buckets is `/b/` instead of `/buckets/`. Initially this fixed that
+        # Unfortunately, CAI omits the collection name, rather than follow Google's API design doc
+        # So we just remove the collection name
+        #
+        # https://cloud.google.com/apis/design/resource_names
+        # See: https://issuetracker.google.com/issues/131586763
+        #
         if api_name == 'storage' and path_segments[0] == 'b':
-            path_segments[0] = "buckets"
+            path_segments.pop(0)
+            # Replace with this if they fix CAI:
+            # path_segments[0] = "buckets"
+
+        if api_name == 'bigtableadmin':
+            api_name = 'bigtable'
 
         resource_path = "/".join(path_segments)
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -84,7 +84,7 @@ test_cases = [
         },
         cls=GcpBigtableInstance,
         type='gcp.bigtableadmin.projects.instances',
-        name='//bigtableadmin.googleapis.com/projects/my_project/instances/my_resource'
+        name='//bigtable.googleapis.com/projects/my_project/instances/my_resource'
     ),
     ResourceTestCase(
         input={
@@ -94,7 +94,7 @@ test_cases = [
         },
         cls=GcpBigtableInstanceIam,
         type='gcp.bigtableadmin.projects.instances.iam',
-        name='//bigtableadmin.googleapis.com/projects/my_project/instances/my_resource'
+        name='//bigtable.googleapis.com/projects/my_project/instances/my_resource'
     ),
     ResourceTestCase(
         input={
@@ -262,7 +262,9 @@ test_cases = [
         },
         cls=GcpStorageBucket,
         type='gcp.storage.buckets',
-        name='//storage.googleapis.com/buckets/my_resource'
+        # This should include the collection name `/buckets/`, but CAI doesn't do that
+        # See: https://issuetracker.google.com/issues/131586763
+        name='//storage.googleapis.com/my_resource'
     ),
     ResourceTestCase(
         input={
@@ -272,7 +274,9 @@ test_cases = [
         },
         cls=GcpStorageBucketIamPolicy,
         type='gcp.storage.buckets.iam',
-        name='//storage.googleapis.com/buckets/my_resource'
+        # This should include the collection name `/buckets/`, but CAI doesn't do that
+        # See: https://issuetracker.google.com/issues/131586763
+        name='//storage.googleapis.com/my_resource'
     ),
     ResourceTestCase(
         input={

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -16,6 +16,9 @@
 import collections
 import pytest
 
+from google.oauth2.credentials import Credentials
+
+from rpe.exceptions import ResourceException
 from rpe.resources import Resource
 from rpe.resources.gcp import GcpAppEngineInstance
 from rpe.resources.gcp import GcpBigqueryDataset
@@ -43,6 +46,9 @@ from rpe.resources.gcp import GcpComputeSubnetwork
 
 test_project = "my_project"
 test_resource_name = "my_resource"
+client_kwargs = {
+    'credentials': Credentials(token='')
+}
 
 ResourceTestCase = collections.namedtuple('ResourceTestCase', 'input cls type name')
 
@@ -50,17 +56,20 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'apps.services.versions.instances',
-            'resource_name': 'apps/my_project/services/default/versions/test-instance/instances/my_resource',
-            'project_id': test_project
+            'name': 'my_resource',
+            'app': 'my_project',
+            'service': 'default',
+            'version': '0123456789',
+            'project_id': test_project,
         },
         cls=GcpAppEngineInstance,
         type='gcp.appengine.apps.services.versions.instances',
-        name='//appengine.googleapis.com/apps/my_project/services/default/versions/test-instance/instances/my_resource'
+        name='//appengine.googleapis.com/apps/my_project/services/default/versions/0123456789/instances/my_resource'
     ),
     ResourceTestCase(
         input={
             'resource_type': 'bigquery.datasets',
-            'resource_name': test_resource_name,
+            'name': test_resource_name,
             'project_id': test_project
         },
         cls=GcpBigqueryDataset,
@@ -70,7 +79,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'bigtableadmin.projects.instances',
-            'resource_name': test_resource_name,
+            'name': test_resource_name,
             'project_id': test_project
         },
         cls=GcpBigtableInstance,
@@ -80,7 +89,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'bigtableadmin.projects.instances.iam',
-            'resource_name': test_resource_name,
+            'name': test_resource_name,
             'project_id': test_project
         },
         cls=GcpBigtableInstanceIam,
@@ -90,8 +99,8 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'cloudfunctions.projects.locations.functions',
-            'resource_name': test_resource_name,
-            'resource_location': 'us-central1-a',
+            'name': test_resource_name,
+            'location': 'us-central1-a',
             'project_id': test_project
         },
         cls=GcpCloudFunction,
@@ -101,8 +110,8 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'cloudfunctions.projects.locations.functions.iam',
-            'resource_name': test_resource_name,
-            'resource_location': 'us-central1-a',
+            'name': test_resource_name,
+            'location': 'us-central1-a',
             'project_id': test_project
         },
         cls=GcpCloudFunctionIam,
@@ -112,8 +121,8 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'compute.disks',
-            'resource_name': test_resource_name,
-            'resource_location': 'us-central1-a',
+            'name': test_resource_name,
+            'location': 'us-central1-a',
             'project_id': test_project
         },
         cls=GcpComputeDisks,
@@ -123,8 +132,8 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'compute.instances',
-            'resource_name': test_resource_name,
-            'resource_location': 'us-central1-a',
+            'name': test_resource_name,
+            'location': 'us-central1-a',
             'project_id': test_project
         },
         cls=GcpComputeInstance,
@@ -134,8 +143,8 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'container.projects.locations.clusters',
-            'resource_name': test_resource_name,
-            'resource_location': 'us-central1-a',
+            'name': test_resource_name,
+            'location': 'us-central1-a',
             'project_id': test_project
         },
         cls=GcpGkeCluster,
@@ -145,8 +154,9 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'container.projects.locations.clusters.nodePools',
-            'resource_name': "parent_resource/nodePools/" + test_resource_name,
-            'resource_location': 'us-central1-a',
+            'name': test_resource_name,
+            'location': 'us-central1-a',
+            'cluster': 'parent_resource',
             'project_id': test_project
         },
         cls=GcpGkeClusterNodepool,
@@ -156,7 +166,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'cloudresourcemanager.projects',
-            'resource_name': test_project,
+            'name': test_project,
             'project_id': test_project
         },
         cls=GcpProject,
@@ -166,7 +176,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'cloudresourcemanager.projects.iam',
-            'resource_name': test_project,
+            'name': test_project,
             'project_id': test_project
         },
         cls=GcpProjectIam,
@@ -176,7 +186,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'serviceusage.services',
-            'resource_name': 'compute.googleapis.com',
+            'name': 'compute.googleapis.com',
             'project_id': test_project
         },
         cls=GcpProjectService,
@@ -186,8 +196,8 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'dataproc.clusters',
-            'resource_name': test_resource_name,
-            'resource_location': 'global',
+            'name': test_resource_name,
+            'location': 'global',
             'project_id': test_project
         },
         cls=GcpDataprocCluster,
@@ -197,7 +207,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'pubsub.projects.subscriptions',
-            'resource_name': test_resource_name,
+            'name': test_resource_name,
             'project_id': test_project
         },
         cls=GcpPubsubSubscription,
@@ -207,7 +217,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'pubsub.projects.subscriptions.iam',
-            'resource_name': test_resource_name,
+            'name': test_resource_name,
             'project_id': test_project
         },
         cls=GcpPubsubSubscriptionIam,
@@ -217,7 +227,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'pubsub.projects.topics',
-            'resource_name': test_resource_name,
+            'name': test_resource_name,
             'project_id': test_project
         },
         cls=GcpPubsubTopic,
@@ -227,7 +237,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'pubsub.projects.topics.iam',
-            'resource_name': test_resource_name,
+            'name': test_resource_name,
             'project_id': test_project
         },
         cls=GcpPubsubTopicIam,
@@ -237,7 +247,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'sqladmin.instances',
-            'resource_name': test_resource_name,
+            'name': test_resource_name,
             'project_id': test_project
         },
         cls=GcpSqlInstance,
@@ -247,7 +257,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'storage.buckets',
-            'resource_name': test_resource_name,
+            'name': test_resource_name,
             'project_id': test_project
         },
         cls=GcpStorageBucket,
@@ -257,7 +267,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'storage.buckets.iam',
-            'resource_name': test_resource_name,
+            'name': test_resource_name,
             'project_id': test_project
         },
         cls=GcpStorageBucketIamPolicy,
@@ -267,8 +277,8 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'compute.subnetworks',
-            'resource_name': test_resource_name,
-            'resource_location': 'us-central1',
+            'name': test_resource_name,
+            'location': 'us-central1',
             'project_id': test_project
         },
         cls=GcpComputeSubnetwork,
@@ -278,7 +288,7 @@ test_cases = [
     ResourceTestCase(
         input={
             'resource_type': 'compute.firewalls',
-            'resource_name': test_resource_name,
+            'name': test_resource_name,
             'project_id': test_project
         },
         cls=GcpComputeFirewall,
@@ -293,14 +303,14 @@ test_cases = [
     test_cases,
     ids=[case.cls.__name__ for case in test_cases])
 def test_gcp_resource_factory(case):
-    r = Resource.factory("gcp", case.input)
+    r = Resource.factory("gcp", **case.input, client_kwargs=client_kwargs)
     assert r.__class__ == case.cls
     assert r.type() == case.type
 
 
 def test_gcp_resource_factory_invalid():
-    with pytest.raises(AssertionError):
-        Resource.factory('gcp', {})
+    with pytest.raises(ResourceException):
+        Resource.factory('gcp')
 
 
 @pytest.mark.parametrize(
@@ -308,5 +318,5 @@ def test_gcp_resource_factory_invalid():
     test_cases,
     ids=[case.cls.__name__ for case in test_cases])
 def test_gcp_full_resource_name(case):
-    r = Resource.factory("gcp", case.input)
+    r = Resource.factory("gcp", **case.input, client_kwargs=client_kwargs)
     assert r.full_resource_name() == case.name

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -303,7 +303,7 @@ test_cases = [
     test_cases,
     ids=[case.cls.__name__ for case in test_cases])
 def test_gcp_resource_factory(case):
-    r = Resource.factory("gcp", **case.input, client_kwargs=client_kwargs)
+    r = Resource.factory("gcp", client_kwargs=client_kwargs, **case.input)
     assert r.__class__ == case.cls
     assert r.type() == case.type
 
@@ -318,5 +318,5 @@ def test_gcp_resource_factory_invalid():
     test_cases,
     ids=[case.cls.__name__ for case in test_cases])
 def test_gcp_full_resource_name(case):
-    r = Resource.factory("gcp", **case.input, client_kwargs=client_kwargs)
+    r = Resource.factory("gcp", client_kwargs=client_kwargs, **case.input)
     assert r.full_resource_name() == case.name

--- a/tests/test_resources_cai.py
+++ b/tests/test_resources_cai.py
@@ -248,3 +248,4 @@ def test_gcp_resource_from_cai_data(case):
         client_kwargs=client_kwargs,
     )
     assert r.__class__ == case.resource_cls
+    assert r.full_resource_name() == case.data.get('name')

--- a/tests/test_resources_cai.py
+++ b/tests/test_resources_cai.py
@@ -1,0 +1,250 @@
+# Copyright 2020 The resource-policy-evaluation-library Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import collections
+import pytest
+
+from google.oauth2.credentials import Credentials
+
+from rpe.resources.gcp import GoogleAPIResource
+from rpe.resources.gcp import GcpAppEngineInstance
+from rpe.resources.gcp import GcpBigqueryDataset
+from rpe.resources.gcp import GcpBigtableInstance
+from rpe.resources.gcp import GcpBigtableInstanceIam
+from rpe.resources.gcp import GcpCloudFunction
+from rpe.resources.gcp import GcpCloudFunctionIam
+from rpe.resources.gcp import GcpComputeInstance
+from rpe.resources.gcp import GcpComputeDisks
+from rpe.resources.gcp import GcpDataprocCluster
+from rpe.resources.gcp import GcpGkeCluster
+from rpe.resources.gcp import GcpGkeClusterNodepool
+from rpe.resources.gcp import GcpProject
+from rpe.resources.gcp import GcpProjectIam
+from rpe.resources.gcp import GcpProjectService
+from rpe.resources.gcp import GcpPubsubSubscription
+from rpe.resources.gcp import GcpPubsubSubscriptionIam
+from rpe.resources.gcp import GcpPubsubTopic
+from rpe.resources.gcp import GcpPubsubTopicIam
+from rpe.resources.gcp import GcpSqlInstance
+from rpe.resources.gcp import GcpStorageBucket
+from rpe.resources.gcp import GcpStorageBucketIamPolicy
+from rpe.resources.gcp import GcpComputeFirewall
+from rpe.resources.gcp import GcpComputeSubnetwork
+
+client_kwargs = {
+    'credentials': Credentials(token='')
+}
+
+CaiTestCase = collections.namedtuple('CaiTestCase', 'data content_type resource_cls')
+
+test_cases = [
+    CaiTestCase(
+        data={
+            "name": "//appengine.googleapis.com/apps/test-project/services/default/versions/1234567890/instances/test-instance",
+            "asset_type": "appengine.googleapis.com/Instance",
+        },
+        content_type="resource",
+        resource_cls=GcpAppEngineInstance
+    ),
+    CaiTestCase(
+        data={
+            "name": "//bigquery.googleapis.com/projects/test-project/datasets/test-resource",
+            "asset_type": "bigquery.googleapis.com/Dataset",
+        },
+        content_type="resource",
+        resource_cls=GcpBigqueryDataset
+    ),
+    CaiTestCase(
+        data={
+            "name": "//bigtable.googleapis.com/projects/test-project/instances/test-resource",
+            "asset_type": "bigtableadmin.googleapis.com/Instance",
+        },
+        content_type="resource",
+        resource_cls=GcpBigtableInstance
+    ),
+    CaiTestCase(
+        data={
+            "name": "//bigtable.googleapis.com/projects/test-project/instances/test-resource",
+            "asset_type": "bigtableadmin.googleapis.com/Instance",
+        },
+        content_type="iam",
+        resource_cls=GcpBigtableInstanceIam
+    ),
+    CaiTestCase(
+        data={
+            "name": "//cloudfunctions.googleapis.com/projects/test-project/locations/us-central1/functions/my-function",
+            "asset_type": "cloudfunctions.googleapis.com/CloudFunction",
+        },
+        content_type="resource",
+        resource_cls=GcpCloudFunction
+    ),
+    CaiTestCase(
+        data={
+            "name": "//cloudfunctions.googleapis.com/projects/test-project/locations/us-central1/functions/my-function",
+            "asset_type": "cloudfunctions.googleapis.com/CloudFunction",
+        },
+        content_type="iam",
+        resource_cls=GcpCloudFunctionIam
+    ),
+    CaiTestCase(
+        data={
+            "name": "//compute.googleapis.com/projects/test-project/zones/us-central1-a/instances/test-resource",
+            "asset_type": "compute.googleapis.com/Instance",
+        },
+        content_type="resource",
+        resource_cls=GcpComputeInstance
+    ),
+    CaiTestCase(
+        data={
+            "name": "//compute.googleapis.com/projects/test-project/zones/us-central1-a/disks/test-resource",
+            "asset_type": "compute.googleapis.com/Disk",
+        },
+        content_type="resource",
+        resource_cls=GcpComputeDisks
+    ),
+    CaiTestCase(
+        data={
+            "name": "//compute.googleapis.com/projects/test-project/regions/asia-east2/subnetworks/test-resource",
+            "asset_type": "compute.googleapis.com/Subnetwork",
+        },
+        content_type="resource",
+        resource_cls=GcpComputeSubnetwork
+    ),
+    CaiTestCase(
+        data={
+            "name": "//compute.googleapis.com/projects/test-project/global/firewalls/test-resource",
+            "asset_type": "compute.googleapis.com/Firewall",
+        },
+        content_type="resource",
+        resource_cls=GcpComputeFirewall
+    ),
+    CaiTestCase(
+        data={
+            "name": "//dataproc.googleapis.com/projects/test-project/regions/us-central1/clusters/test-resource",
+            "asset_type": "dataproc.googleapis.com/Cluster",
+        },
+        content_type="resource",
+        resource_cls=GcpDataprocCluster
+    ),
+    CaiTestCase(
+        data={
+            "name": "//container.googleapis.com/projects/test-project/locations/us-central1/clusters/test-resource",
+            "asset_type": "container.googleapis.com/Cluster",
+        },
+        content_type="resource",
+        resource_cls=GcpGkeCluster
+    ),
+    CaiTestCase(
+        data={
+            "name": "//container.googleapis.com/projects/test-project/locations/us-central1/clusters/foofoo123/nodePools/test-resource",
+            "asset_type": "container.googleapis.com/NodePool",
+        },
+        content_type="resource",
+        resource_cls=GcpGkeClusterNodepool
+    ),
+    CaiTestCase(
+        data={
+            "name": "//pubsub.googleapis.com/projects/test-project/subscriptions/test-resource",
+            "asset_type": "pubsub.googleapis.com/Subscription",
+        },
+        content_type="resource",
+        resource_cls=GcpPubsubSubscription
+    ),
+    CaiTestCase(
+        data={
+            "name": "//pubsub.googleapis.com/projects/test-project/subscriptions/test-resource",
+            "asset_type": "pubsub.googleapis.com/Subscription",
+        },
+        content_type="iam",
+        resource_cls=GcpPubsubSubscriptionIam
+    ),
+    CaiTestCase(
+        data={
+            "name": "//pubsub.googleapis.com/projects/test-project/topics/test-resource",
+            "asset_type": "pubsub.googleapis.com/Topic",
+        },
+        content_type="resource",
+        resource_cls=GcpPubsubTopic
+    ),
+    CaiTestCase(
+        data={
+            "name": "//pubsub.googleapis.com/projects/test-project/topics/test-resource",
+            "asset_type": "pubsub.googleapis.com/Topic",
+        },
+        content_type="iam",
+        resource_cls=GcpPubsubTopicIam
+    ),
+    CaiTestCase(
+        data={
+            "name": "//storage.googleapis.com/test-resource",
+            "asset_type": "storage.googleapis.com/Bucket",
+        },
+        content_type="resource",
+        resource_cls=GcpStorageBucket
+    ),
+    CaiTestCase(
+        data={
+            "name": "//storage.googleapis.com/test-resource",
+            "asset_type": "storage.googleapis.com/Bucket",
+        },
+        content_type="iam",
+        resource_cls=GcpStorageBucketIamPolicy
+    ),
+    CaiTestCase(
+        data={
+            "name": "//cloudsql.googleapis.com/projects/test-project/instances/test-resource",
+            "asset_type": "sqladmin.googleapis.com/Instance",
+        },
+        content_type="resource",
+        resource_cls=GcpSqlInstance
+    ),
+    CaiTestCase(
+        data={
+            "name": "//cloudresourcemanager.googleapis.com/projects/test-resource",
+            "asset_type": "cloudresourcemanager.googleapis.com/Project",
+        },
+        content_type="resource",
+        resource_cls=GcpProject
+    ),
+    CaiTestCase(
+        data={
+            "name": "//cloudresourcemanager.googleapis.com/projects/test-resource",
+            "asset_type": "cloudresourcemanager.googleapis.com/Project",
+        },
+        content_type="iam",
+        resource_cls=GcpProjectIam
+    ),
+    CaiTestCase(
+        data={
+            "name": "//serviceusage.googleapis.com/projects/179590471157/services/test-resource",
+            "asset_type": "serviceusage.googleapis.com/Service",
+        },
+        content_type="resource",
+        resource_cls=GcpProjectService
+    ),
+]
+
+@pytest.mark.parametrize(
+    "case",
+    test_cases,
+    ids=[case.resource_cls.__name__ for case in test_cases])
+def test_gcp_resource_from_cai_data(case):
+    r = GoogleAPIResource.from_cai_data(
+        case.data.get('name'),
+        case.data.get('asset_type'),
+        case.content_type,
+        client_kwargs=client_kwargs,
+    )
+    assert r.__class__ == case.resource_cls


### PR DESCRIPTION
Add support for creating resource objects from the asset_type, content_type, and full resource name used by CAI (https://cloud.google.com/asset-inventory/docs/resource-name-format)