### PR TITLE
Fix resources missing cai_types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ cache:
   - "${HOME}/.cache"
 matrix:
   include:
-  - python: 3.4
-    env: TOXENV=py34
-  - python: 3.5
-    env: TOXENV=py35
   - python: 3.6
     env: TOXENV=py36
   - python: 3.7

--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -411,6 +411,8 @@ class GcpAppEngineInstance(GoogleAPIResource):
     readiness_value = 'RUNNING'
     update_method = "debug"
 
+    cai_type = 'appengine.googleapis.com/Instance'  # this is made-up based on existing appengine types
+
     required_resource_data = ['name', 'app', 'service', 'version']
 
     cai_type = None             # unknown
@@ -497,8 +499,6 @@ class GcpBigtableInstanceIam(GcpBigtableInstance):
     readiness_key = None
     readiness_value = None
 
-    cai_type = "bigtableadmin.googleapis.com/Instance"
-
     def _get_request_args(self):
         return {
             'resource': 'projects/{}/instances/{}'.format(
@@ -556,8 +556,6 @@ class GcpCloudFunctionIam(GcpCloudFunction):
     parent_cls = GcpCloudFunction
     get_method = "getIamPolicy"
     update_method = "setIamPolicy"
-
-    cai_type = "cloudfunctions.googleapis.com/CloudFunction"  # unreleased
 
     def _get_request_args(self):
         return {
@@ -813,8 +811,6 @@ class GcpPubsubSubscriptionIam(GcpPubsubSubscription):
     get_method = "getIamPolicy"
     update_method = "setIamPolicy"
 
-    cai_type = "pubsub.googleapis.com/Subscription"
-
     def _get_request_args(self):
         return {
             'resource': 'projects/{}/subscriptions/{}'.format(
@@ -874,8 +870,6 @@ class GcpPubsubTopicIam(GcpPubsubTopic):
     parent_cls = GcpPubsubTopic
     get_method = "getIamPolicy"
     update_method = "setIamPolicy"
-
-    cai_type = "pubsub.googleapis.com/Topic"
 
     def _get_request_args(self):
         return {
@@ -1002,7 +996,7 @@ class GcpProjectService(GoogleAPIResource):
 
     required_resource_data = ['name', 'project_id']
 
-    cai_type = None
+    cai_type = 'serviceusage.googleapis.com/Service'
 
     def _get_request_args(self):
         return {

--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -27,6 +27,7 @@ from googleapiclienthelpers.waiter import Waiter
 # client for resource manager, will be lazy created later
 resource_manager_projects = None
 
+
 class GoogleAPIResource(Resource):
 
     # Names of the get and update methods. Most are the same but override in
@@ -34,7 +35,7 @@ class GoogleAPIResource(Resource):
     resource_property = None
     get_method = "get"
     update_method = "update"
-    required_resource_data = [ 'name' ]
+    required_resource_data = ['name']
 
     parent_cls = None
 
@@ -67,7 +68,6 @@ class GoogleAPIResource(Resource):
             **self._client_kwargs
         )
 
-
         # Support original update method until we can deprecate it
         self.update = self.remediate
 
@@ -75,7 +75,7 @@ class GoogleAPIResource(Resource):
         if self.parent_cls:
 
             self.parent_resource = self.parent_cls(
-                client_kwargs = self._client_kwargs,
+                client_kwargs=self._client_kwargs,
                 **self._resource_data.copy()
             )
 
@@ -92,10 +92,8 @@ class GoogleAPIResource(Resource):
                 )
             )
 
-
     def is_property(self):
         return self.resource_property is not None
-
 
     @staticmethod
     def _extract_cai_name_data(name):
@@ -109,12 +107,12 @@ class GoogleAPIResource(Resource):
 
 
             # Less-common resource data
-            ## AppEngine
+            #  AppEngine
             'app': r'/apps/([^\/]+)/',
             'service': r'/services/([^\/]+)/',
             'version': r'/versions/([^\/]+)/',
 
-            ## NodePools
+            #  NodePools
             'cluster': r'/clusters/([^\/]+)/',
         }
 
@@ -127,7 +125,6 @@ class GoogleAPIResource(Resource):
                 resource_data[field_name] = m.group(1)
 
         return resource_data
-
 
     @staticmethod
     def from_cai_data(resource_name, asset_type, content_type='resource', client_kwargs={}):
@@ -188,7 +185,6 @@ class GoogleAPIResource(Resource):
             client_kwargs=client_kwargs,
             **resource_data
         )
-
 
     @staticmethod
     def factory(client_kwargs={}, **kwargs):


### PR DESCRIPTION
Add CAI types for appengine instances and project services. Also remove redundant ones that would be inherited from parent objects (the IAM resources in particular)

Also add to_dict call and reformat ancestry data for resources.