### PR TITLE
Allow passing explicit project_id

### DIFF
--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -109,7 +109,7 @@ class GoogleAPIResource(Resource):
         return resource_data
 
     @staticmethod
-    def from_cai_data(resource_name, asset_type, content_type='resource', client_kwargs={}):
+    def from_cai_data(resource_name, asset_type, content_type='resource', project_id=None, client_kwargs={}):
 
         # CAI classifies things by content_type (ex: resource or iam)
         # and asset_type (ex: storage bucket or container cluster)
@@ -162,6 +162,10 @@ class GoogleAPIResource(Resource):
         cls = asset_type_map.get(asset_type)
 
         resource_data = GoogleAPIResource._extract_cai_name_data(resource_name)
+
+        # if the project_id was passed, and its wasnt found in the resource name, add it
+        if project_id and 'project_id' not in resource_data:
+            resource_data['project_id'] = project_id
 
         return cls(
             client_kwargs=client_kwargs,

--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -468,8 +468,6 @@ class GcpAppEngineInstance(GoogleAPIResource):
 
     required_resource_data = ['name', 'app', 'service', 'version']
 
-    cai_type = None             # unknown
-
     def _get_request_args(self):
         return {
             'appsId': self._resource_data['app'],


### PR DESCRIPTION
When using CAI to create resource objects, we may not always be able to get the project_id. Example: Cloud storage buckets. This allows passing of that explicitly, and is only used if its not found in the resource's name