### PR TITLE
Add terminal states to GKE Cluster

### DIFF
--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -765,6 +765,7 @@ class GcpGkeCluster(GoogleAPIResource):
     version = "v1"
     readiness_key = 'status'
     readiness_value = 'RUNNING'
+    readiness_terminal_values = ['ERROR', 'DEGRADED']
 
     required_resource_data = ['name', 'location', 'project_id']
 


### PR DESCRIPTION
Ran into some GKE clusters in an ERROR state, so lets exclude those. Also found GRPC protocol files indicating there's also a DEGRADED state which we should wait to be fixed as it requires manual intervention