### PR TITLE
Make to_dict() safe

### DIFF
--- a/rpe/resources/gcp.py
+++ b/rpe/resources/gcp.py
@@ -139,8 +139,13 @@ class GoogleAPIResource(Resource):
         details = self._resource_data.copy()
         details.update({
             'resource_type': self.resource_type,
-            'full_resource_name': self.full_resource_name(),
         })
+
+        try:
+            details['full_resource_name'] = self.full_resource_name()
+        except Exception:
+            details['full_resource_name'] = None
+
         return details
 
     def type(self):


### PR DESCRIPTION
We should avoid raising exceptions in to_dict(). Since the full_resource_name() call relies on the google-api-python-client it has the potential to raise an Exception