### PR TITLE
Minor fixes for python policy engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ class GCPBucketVersioningPolicy:
         pass
 ```
 
+When you configure your RPE object, you provide the path to your python package. That package doesn't need to be installed, it will be loaded dynamically. The path you provide should contain an `__init__.py` file with every policy class you wish to use. These can be defined directly in that file, or imported. Since RPElib takes care of importing the package, you will be able to use relative imports in your python files. For example your directory structure might look like this:
+
+```
+/etc/rpe/policies-python
+* __init__.py
+* policy1.py
+* policy2.py
+```
+
+And your `__init__.py` might look like this:
+
+```python
+# __init__.py
+from .policy1 import MyFirstPythonPolicy
+from .policy2 import AnotherPythonPolicy, YetAnotherPolicy
+```
+
 ## Resources
 
 `Resources` must define the following functions
@@ -140,7 +157,54 @@ for e in evals:
         e.remediate()
 ```
 
+#### Using the Python engine
 
+Using the Python policy engine is similar to the above:
+
+```python
+from rpe import RPE
+from rpe.resources import GoogleAPIResource
+
+config = {
+    'policy_engines': [
+        {
+            'type': 'python',
+            'path': '/etc/rpe/policies-python'
+        }
+    ]
+}
+
+rpe = RPE(config)
+
+# Create resource objects, and evaluate as needed
+```
+
+And your policies may look like this:
+
+/etc/rpe/policies-python/__init__.py
+```python
+from .gcs_policy import GCPBucketVersioningPolicy
+```
+
+/etc/rpe/policies-python/gcs_policy.py
+```python
+class GCPBucketVersioningPolicy:
+
+    description = 'Require object versioning for storage buckets'
+    applies_to = ['cloudresourcemanager.googleapis.com/Project']
+
+    @classmethod
+    def compliant(cls, resource):
+        # Return true/false if the resource is compliant
+
+    @classmethod
+    def excluded(cls, resource):
+        # Return true/false if the resource is excluded
+
+    @classmethod
+    def remediate(cls, resource):
+        # Enable versioning
+```
 
 # Applications using rpe-lib
 

--- a/rpe/engines/python.py
+++ b/rpe/engines/python.py
@@ -15,24 +15,32 @@
 
 import importlib.util
 import inspect
+import sys
 
 from rpe.policy import Evaluation, Policy
 
 
 class PythonPolicyEngine:
 
-    _policies={}
+    counter = 0
 
     def __init__(self, package_path):
+
+        self._policies={}
         self.package_path = package_path
+        PythonPolicyEngine.counter += 1
+        self.package_name = 'rpe.plugins.policies.py_' + str(PythonPolicyEngine.counter)
+
         self._load_policies()
 
     def _load_policies(self):
         spec = importlib.util.spec_from_file_location(
-            "pypol",
+            self.package_name,
             "{}/__init__.py".format(self.package_path)
         )
         module = importlib.util.module_from_spec(spec)
+        sys.modules[self.package_name] = module
+
         spec.loader.exec_module(module)
 
         for name, obj in inspect.getmembers(module):

--- a/rpe/engines/python.py
+++ b/rpe/engines/python.py
@@ -71,17 +71,31 @@ class PythonPolicyEngine:
             self._policies.items()
         ))
 
-        evals = [
-            Evaluation(
-                resource=resource,
-                engine=self,
-                policy_id=policy_name,
-                compliant=policy_cls.compliant(resource),
-                excluded=policy_cls.excluded(resource),
-                remediable=hasattr(policy_cls, 'remediate')
-            )
-            for policy_name,policy_cls in matched_policies.items()
-        ]
+        # Loop over policy and build evals, so we can catch exceptions
+
+        evals = []
+
+        for policy_name, policy_cls in matched_policies.items():
+            try:
+
+                # Ensure that these are boolean
+                compliant = policy_cls.compliant(resource) is True
+                excluded = policy_cls.excluded(resource) is True
+
+                ev = Evaluation(
+                    resource=resource,
+                    engine=self,
+                    policy_id=policy_name,
+                    compliant=compliant,
+                    excluded=excluded,
+                    remediable=hasattr(policy_cls, 'remediate')
+                )
+
+                evals.append(ev)
+
+            # These are user-provided modules, we need to catch any exception
+            except Exception as e:
+                print(f'Evaluation exception. Policy: {policy_name}, Message: {str(e)}')
 
         return evals
 


### PR DESCRIPTION
Without manually adding the module to sys.modules, relative imports in the `__init__.py` of a python policy don't work. Manually adding the module, the executing it, resolves the issue. There's probably a better way to do this with importlib, but I couldn't figure it out.

Also, we had previously hard-coded the module name as `pypol`. This puts the python policy module into the `rpe.plugins.policies` namespace, and uses unique names to allow multiple python policy modules.
