### PR TITLE
Add support for storing evaluation artifacts

### DIFF
--- a/rpe/engines/opa.py
+++ b/rpe/engines/opa.py
@@ -57,14 +57,16 @@ class OpenPolicyAgent(Engine):
 
     # Perform an evaluation on a given resource
     def evaluate(self, resource):
+        resource_data = resource.get()
+
         input = {
-            'input': resource.get(),
+            'input': resource_data,
         }
 
         evals = self._opa_request('rpe/evaluate', method='POST', data=input)
 
         return [
-            Evaluation(engine=self, resource=resource, **ev)
+            Evaluation(engine=self, resource=resource, evaluation_artifact=resource_data, **ev)
             for ev in evals
         ]
 

--- a/rpe/policy.py
+++ b/rpe/policy.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
 from rpe.engines import Engine
@@ -20,6 +20,7 @@ class Evaluation:
     compliant: bool
     excluded: bool
     remediable: bool
+    evaluation_artifact: dict = field(default_factory=dict)  # Data used during evaluation
 
     def remediate(self):
         return self.engine.remediate(self.resource, self.policy_id)


### PR DESCRIPTION
When an evaluation is made, it would be nice to store what we're evaluating. This adds an optional field (evaluation_artifact) to the `Evaluation` class, to store details about what was evaluated. The OPA policy engine is updated to store the data it sends OPA in the Evaluation objects it returns.

