### PR TITLE
Add oauth2client v3.0.0 so that built-in default caching works

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ google-api-python-client
 google-api-python-client-helpers>=1.2.6
 jmespath
 tenacity
+oauth2client==3.0.0 # HACK to get discovery doc caching working


### PR DESCRIPTION
See: https://github.com/googleapis/google-api-python-client/issues/1061

Caching is enabled by default, but is disabled if you don't have specific versions of the deprecated oauth2client library. This PR adds oauth2client and pins it to an appropriate version. Simply having that installed should result in discovery documents being cached automatically.