### PR TITLE
Pin to google-api-python-client 2.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-google-api-python-client
 google-api-python-client-helpers>=1.2.6
+google-api-python-client==2.0.2
 jmespath
 tenacity
-oauth2client==3.0.0 # HACK to get discovery doc caching working


### PR DESCRIPTION
This release builds in the discovery docs, which also means we can drop the
module to enable discovery doc download caching.